### PR TITLE
General code cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+.settings/
+.classpath
+.project
 /target/
 /work/

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ You can find more info on the [plugin's page](https://plugins.jenkins.io/extra-t
 Features
 --------
 
+* Batch command installer for tool installations on Windows supporting variable substitution.
 * "Install from specified folder" - setup without any actions (ex, "installation" from a shared directory)
 * "Skip or fail installation" - prints warnings during the installation and/or fails the installation
 

--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ Features
 
 License
 --------
-[MIT License][http://www.opensource.org/licenses/mit-license.php]
+[MIT License](http://www.opensource.org/licenses/mit-license.php)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ You can find more info on the [plugin's page](https://plugins.jenkins.io/extra-t
 Features
 --------
 
-* Batch command installer for tool installations on Windows supporting variable substitution.
+* Batch command installer for tool installations on Windows. 
+  * `@Deprecated`. Jenkins Core supports such installer since 1.549 (see [JENKINS-21202](https://issues.jenkins-ci.org/browse/JENKINS-21202))
 * "Install from specified folder" - setup without any actions (ex, "installation" from a shared directory)
 * "Skip or fail installation" - prints warnings during the installation and/or fails the installation
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ You can find more info on the [plugin's page](https://plugins.jenkins.io/extra-t
 Features
 --------
 
-* Batch command installer for tool installations on Windows. 
-  * `@Deprecated`. Jenkins Core supports such installer since 1.549 (see [JENKINS-21202](https://issues.jenkins-ci.org/browse/JENKINS-21202))
 * "Install from specified folder" - setup without any actions (ex, "installation" from a shared directory)
 * "Skip or fail installation" - prints warnings during the installation and/or fails the installation
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <url>https://wiki.jenkins.io/display/JENKINS/Extra+Tool+Installers+Plugin</url>
 
     <properties>
-        <jenkins.version>2.7.4</jenkins.version>
+        <jenkins.version>2.60.3</jenkins.version>
         <java.level>8</java.level>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
     <url>https://wiki.jenkins.io/display/JENKINS/Extra+Tool+Installers+Plugin</url>
 
     <properties>
-        <jenkins.version>1.651.3</jenkins.version>
-        <java.level>7</java.level>
+        <jenkins.version>2.7.4</jenkins.version>
+        <java.level>8</java.level>
     </properties>
 
     <repositories>
@@ -47,8 +47,8 @@
         <connection>scm:git:ssh://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <licenses>
         <license>

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/extratoolinstallers/installers/BatchCommandInstaller.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/extratoolinstallers/installers/BatchCommandInstaller.java
@@ -26,6 +26,8 @@ package com.synopsys.arc.jenkinsci.plugins.extratoolinstallers.installers;
 
 import hudson.Extension;
 import hudson.FilePath;
+import hudson.model.Descriptor;
+import hudson.model.DescriptorVisibilityFilter;
 import hudson.model.Node;
 import hudson.model.TaskListener;
 import hudson.tasks.CommandInterpreter;
@@ -113,6 +115,19 @@ public class BatchCommandInstaller extends AbstractExtraToolInstaller {
             } else {
                 return FormValidation.error(Messages.BatchCommandInstaller_no_toolHome());
             }
+        }
+    }
+
+    /**
+     * Prevents the {@link BatchCommandInstaller} from being selectable for new
+     * installers.
+     */
+    @Extension
+    public static class BatchCommandInstallerDescriptorVisibilityFilter extends DescriptorVisibilityFilter {
+        @SuppressWarnings("rawtypes")
+        @Override
+        public boolean filter(Object context, Descriptor descriptor) {
+            return !(descriptor instanceof DescriptorImpl);
         }
     }
 }

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/extratoolinstallers/installers/BatchCommandInstaller.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/extratoolinstallers/installers/BatchCommandInstaller.java
@@ -26,8 +26,6 @@ package com.synopsys.arc.jenkinsci.plugins.extratoolinstallers.installers;
 
 import hudson.Extension;
 import hudson.FilePath;
-import hudson.model.Descriptor;
-import hudson.model.DescriptorVisibilityFilter;
 import hudson.model.Node;
 import hudson.model.TaskListener;
 import hudson.tasks.CommandInterpreter;
@@ -115,19 +113,6 @@ public class BatchCommandInstaller extends AbstractExtraToolInstaller {
             } else {
                 return FormValidation.error(Messages.BatchCommandInstaller_no_toolHome());
             }
-        }
-    }
-
-    /**
-     * Prevents the {@link BatchCommandInstaller} from being selectable for new
-     * installers.
-     */
-    @Extension
-    public static class BatchCommandInstallerDescriptorVisibilityFilter extends DescriptorVisibilityFilter {
-        @SuppressWarnings("rawtypes")
-        @Override
-        public boolean filter(Object context, Descriptor descriptor) {
-            return !(descriptor instanceof DescriptorImpl);
         }
     }
 }

--- a/src/main/resources/com/synopsys/arc/jenkinsci/plugins/extratoolinstallers/installers/Messages.properties
+++ b/src/main/resources/com/synopsys/arc/jenkinsci/plugins/extratoolinstallers/installers/Messages.properties
@@ -5,4 +5,4 @@ SharedDirectoryInstaller.DescriptorImpl.displayName=Use tool from the specified 
 SharedDirectoryInstaller.no_toolHome=Must provide a tool home directory.
 StubInstaller.displayName=Skip or fail the installation
 StubInstaller.noMessage=No message specified. Default message will be used.
-StubInstaller.defaultMessage=Installation will be skipped
+StubInstaller.defaultMessage=Installation will be skipped.


### PR DESCRIPTION
- Minimum Jenkins version updated to 2.60.3.
-- This makes it much easier to dev/test the plugin, as the custom tools plugin has dependencies which require a more recent Jenkins.
- Java version bumped from 7 to 8 to match updated Jenkins version.
- Fixed deprecation warnings caused by use of (now-deprecated) Jenkins.getActiveInstance()
- Fixed javadoc warnings caused by missing/incorrect comments in EnvStringParseHelper.
-- Also tidied a lot of trailing whitespace.
- Corrected typo in README.md license link.
- Gitignored files present when using Eclipse IDE.