### PR TITLE
Added "Try any of..." installer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Features
   * `@Deprecated`. Jenkins Core supports such installer since 1.549 (see [JENKINS-21202](https://issues.jenkins-ci.org/browse/JENKINS-21202))
 * "Install from specified folder" - setup without any actions (ex, "installation" from a shared directory)
 * "Skip or fail installation" - prints warnings during the installation and/or fails the installation
+* "Try any of ..." - try/retry multiple installers until one works.
 
 
 License

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,22 @@
         </developer>
     </developers>
 
+    <dependencies>
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.9.5</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <scm>
         <connection>scm:git:ssh://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/${project.artifactId}-plugin.git</developerConnection>

--- a/src/main/java/io/jenkins/plugins/extratoolinstallers/installers/AnyOfInstaller.java
+++ b/src/main/java/io/jenkins/plugins/extratoolinstallers/installers/AnyOfInstaller.java
@@ -1,0 +1,308 @@
+package io.jenkins.plugins.extratoolinstallers.installers;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+import com.synopsys.arc.jenkinsci.plugins.extratoolinstallers.utils.ExtraToolInstallersException;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.Node;
+import hudson.model.TaskListener;
+import hudson.tools.InstallSourceProperty;
+import hudson.tools.ToolInstallation;
+import hudson.tools.ToolInstaller;
+import hudson.tools.ToolInstallerDescriptor;
+import hudson.util.FormValidation;
+
+/**
+ * Installs tools using "any of" the installation methods provided. The
+ * installation is deemed a success upon any success, ignoring any earlier
+ * failures.
+ */
+public class AnyOfInstaller extends ToolInstaller {
+    /**
+     * The list of installers we will attempt. Cannot be empty for this class to
+     * be valid.
+     */
+    @CheckForNull
+    private /* almost final */ InstallSourceProperty installers;
+
+    /**
+     * The number of times we will attempt each installer before moving onto the
+     * next in the list.
+     */
+    private /* almost final */ int attemptsPerInstaller;
+
+    /**
+     * The number of times we will attempt the list as a whole. Must not be less
+     * than one.
+     */
+    private /* almost final */ int attemptsOfWholeList;
+
+    @DataBoundConstructor
+    public AnyOfInstaller() {
+        // we never have a label ourselves; we only ever have labels in our
+        // installers.
+        super(null);
+    }
+
+    @CheckForNull
+    public InstallSourceProperty getInstallers() {
+        return installers;
+    }
+
+    @DataBoundSetter
+    public void setInstallers(@Nullable final InstallSourceProperty installers) {
+        this.installers = installers;
+        if (super.tool != null) {
+            installers.setTool(super.tool);
+        }
+    }
+
+    /**
+     * The number of times we will attempt each installer before moving onto the
+     * next in the list. Will always be one or more.
+     * 
+     * @return The value set by {@link #setAttemptsPerInstaller(int)} if that
+     *         was 1 or more, else 1.
+     */
+    public int getAttemptsPerInstaller() {
+        return Math.max(1, attemptsPerInstaller);
+    }
+
+    @DataBoundSetter
+    public void setAttemptsPerInstaller(final int attemptsPerInstaller) {
+        this.attemptsPerInstaller = attemptsPerInstaller;
+    }
+
+    /**
+     * The number of times we will attempt each installer before moving onto the
+     * next in the list. Will always return one or more.
+     * 
+     * @return The value set by {@link #setAttemptsOfWholeList(int)} if that was
+     *         1 or more, else 1.
+     */
+    public int getAttemptsOfWholeList() {
+        return Math.max(1, attemptsOfWholeList);
+    }
+
+    @DataBoundSetter
+    public void setAttemptsOfWholeList(final int attemptsOfWholeList) {
+        this.attemptsOfWholeList = attemptsOfWholeList;
+    }
+
+    @Override
+    protected void setTool(final ToolInstallation t) {
+        super.setTool(t);
+        if (installers != null) {
+            installers.setTool(t);
+        }
+    }
+
+    @Override
+    public boolean appliesTo(final Node node) {
+        // We "apply" if any of our installers apply.
+        // We have no separate existence of our own.
+        final List<? extends ToolInstaller> ourInstallers = getOurInstallers();
+        for (final ToolInstaller installer : ourInstallers) {
+            if (installer.appliesTo(node)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public FilePath performInstallation(final ToolInstallation tool, final Node node, final TaskListener log)
+            throws IOException, InterruptedException {
+        // Work out what we are going to do
+        final List<? extends ToolInstaller> allDefinedInstallers = getOurInstallers();
+        final int numberOfConfiguredInstallers = allDefinedInstallers.size();
+        final Map<Integer, ToolInstaller> allApplicableInstallersByIndex = calcInstallersThatApplyToNode(node,
+                allDefinedInstallers);
+        final Map<Integer, String> allApplicableInstallerNamesByIndex = calcInstallerDisplayNames(
+                allApplicableInstallersByIndex);
+        final int maxWholeListAttempts = getAttemptsOfWholeList();
+        final int maxAttemptsPerInstaller = getAttemptsPerInstaller();
+        // Now loop through all attempts until either one works and we return
+        // or until we run out of tries, in which case we throw the last
+        // exception
+        Exception lastExceptionEncountered = null;
+        for (int wholeListAttempt = 1; wholeListAttempt <= maxWholeListAttempts; wholeListAttempt++) {
+            for (final Map.Entry<Integer, ToolInstaller> entry : allApplicableInstallersByIndex.entrySet()) {
+                final ToolInstaller installer = entry.getValue();
+                final Integer indexOfConfiguredInstaller = entry.getKey();
+                for (int installerAttempt = 1; installerAttempt <= maxAttemptsPerInstaller; installerAttempt++) {
+                    try {
+                        final FilePath result = installer.performInstallation(tool, node, log);
+                        return result; // success
+                    } catch (IOException | RuntimeException ex) {
+                        lastExceptionEncountered = ex;
+                        final String displayNameOfThisInstaller = allApplicableInstallerNamesByIndex
+                                .get(indexOfConfiguredInstaller);
+                        final String whatToReport = ex.toString();
+                        logAttempt(log, whatToReport, wholeListAttempt, maxWholeListAttempts,
+                                numberOfConfiguredInstallers, indexOfConfiguredInstaller, displayNameOfThisInstaller,
+                                maxAttemptsPerInstaller, installerAttempt);
+                    }
+                }
+            }
+        }
+        throw new ExtraToolInstallersException(this, Messages.AnyOfInstaller_all_failed(), lastExceptionEncountered);
+    }
+
+    @Nonnull
+    private List<? extends ToolInstaller> getOurInstallers() {
+        if (installers == null || installers.installers == null) {
+            return Collections.emptyList();
+        }
+        return installers.installers.getAll(ToolInstaller.class);
+    }
+
+    /**
+     * Determines which installers <code>appliesTo</code> the given node.
+     * 
+     * @param node
+     *            The node
+     * @param installers
+     *            The installers to be considered
+     * @return A Map of installers, indexed by where they were in the list
+     *         (starting from 1).
+     */
+    private static Map<Integer, ToolInstaller> calcInstallersThatApplyToNode(final Node node,
+            final List<? extends ToolInstaller> installers) {
+        final Map<Integer, ToolInstaller> allApplicableInstallersByIndex = new LinkedHashMap<>(installers.size());
+        int index = 0;
+        for (final ToolInstaller installer : installers) {
+            index++;
+            if (installer.appliesTo(node)) {
+                allApplicableInstallersByIndex.put(Integer.valueOf(index), installer);
+            }
+        }
+        return allApplicableInstallersByIndex;
+    }
+
+    /**
+     * Determines the human-readable names of the installers.
+     * 
+     * @param installersByIndex
+     *            Map of installers.
+     * @return Map of human-readable names of the installers, indexed by the
+     *         same key as the installer was.
+     */
+    private static <K> Map<K, String> calcInstallerDisplayNames(final Map<K, ToolInstaller> installersByIndex) {
+        final Map<K, String> installerNamesByIndex = new IdentityHashMap<>(installersByIndex.size());
+        for (final Map.Entry<K, ToolInstaller> entry : installersByIndex.entrySet()) {
+            final ToolInstaller installer = entry.getValue();
+            final K index = entry.getKey();
+            final String installerName = installer.getDescriptor().getDisplayName();
+            installerNamesByIndex.put(index, installerName);
+        }
+        return installerNamesByIndex;
+    }
+
+    /**
+     * Logs a message to the build log, indicating the point in our proceedings
+     * that the message relates to, using as little text as possile to do it.
+     */
+    private static void logAttempt(final TaskListener log, final String whatToReport, final int wholeListAttempt,
+            final int maxWholeListAttempts, final int numberOfConfiguredOfInstallers,
+            final Integer indexOfConfiguredInstaller, final String nameOfConfiguredInstaller,
+            final int maxAttemptsPerInstaller, final int installerAttempt) {
+        final String msg;
+        // Select the best localized message given our config - if we're not
+        // doing multiple loops then there's no point saying we're on loop 1 of
+        // 1 etc.
+        if (maxWholeListAttempts > 1) {
+            // We have multiple loops, so we need to use "loops" messages not
+            // "1loop" variants so we that our log message specifies which
+            // attempt that was.
+            if (numberOfConfiguredOfInstallers > 1) {
+                // We have multiple configured installers, so we need to use
+                // "installers" messages not "1installer" variants so that our
+                // log message specifies which installer that was.
+                if (maxAttemptsPerInstaller > 1) {
+                    // We have multiple attempts per installer, so we need to
+                    // use "attempts" messages not "1attempt" variants so that
+                    // our log message specifies which attempt it was.
+                    msg = Messages.AnyOfInstaller_loops_installers_attempts(wholeListAttempt, maxWholeListAttempts,
+                            indexOfConfiguredInstaller, numberOfConfiguredOfInstallers, nameOfConfiguredInstaller,
+                            installerAttempt, maxAttemptsPerInstaller, whatToReport);
+                } else {
+                    msg = Messages.AnyOfInstaller_loops_installers_1attempt(wholeListAttempt, maxWholeListAttempts,
+                            indexOfConfiguredInstaller, numberOfConfiguredOfInstallers, nameOfConfiguredInstaller,
+                            installerAttempt, maxAttemptsPerInstaller, whatToReport);
+                }
+            } else {
+                if (maxAttemptsPerInstaller > 1) {
+                    msg = Messages.AnyOfInstaller_loops_1installer_attempts(wholeListAttempt, maxWholeListAttempts,
+                            indexOfConfiguredInstaller, numberOfConfiguredOfInstallers, nameOfConfiguredInstaller,
+                            installerAttempt, maxAttemptsPerInstaller, whatToReport);
+                } else {
+                    msg = Messages.AnyOfInstaller_loops_1installer_1attempt(wholeListAttempt, maxWholeListAttempts,
+                            indexOfConfiguredInstaller, numberOfConfiguredOfInstallers, nameOfConfiguredInstaller,
+                            installerAttempt, maxAttemptsPerInstaller, whatToReport);
+                }
+            }
+        } else {
+            if (numberOfConfiguredOfInstallers > 1) {
+                if (maxAttemptsPerInstaller > 1) {
+                    msg = Messages.AnyOfInstaller_1loop_installers_attempts(wholeListAttempt, maxWholeListAttempts,
+                            indexOfConfiguredInstaller, numberOfConfiguredOfInstallers, nameOfConfiguredInstaller,
+                            installerAttempt, maxAttemptsPerInstaller, whatToReport);
+                } else {
+                    msg = Messages.AnyOfInstaller_1loop_installers_1attempt(wholeListAttempt, maxWholeListAttempts,
+                            indexOfConfiguredInstaller, numberOfConfiguredOfInstallers, nameOfConfiguredInstaller,
+                            installerAttempt, maxAttemptsPerInstaller, whatToReport);
+                }
+            } else {
+                if (maxAttemptsPerInstaller > 1) {
+                    msg = Messages.AnyOfInstaller_1loop_1installer_attempts(wholeListAttempt, maxWholeListAttempts,
+                            indexOfConfiguredInstaller, numberOfConfiguredOfInstallers, nameOfConfiguredInstaller,
+                            installerAttempt, maxAttemptsPerInstaller, whatToReport);
+                } else {
+                    msg = Messages.AnyOfInstaller_1loop_1installer_1attempt(wholeListAttempt, maxWholeListAttempts,
+                            indexOfConfiguredInstaller, numberOfConfiguredOfInstallers, nameOfConfiguredInstaller,
+                            installerAttempt, maxAttemptsPerInstaller, whatToReport);
+                }
+            }
+        }
+        // now log it
+        final PrintStream output = log.getLogger();
+        output.println(msg);
+    }
+
+    /**
+     * Descriptor for the {@link AnyOfInstaller}.
+     */
+    @Extension @Symbol("anyOf")
+    public static class DescriptorImpl extends ToolInstallerDescriptor<AnyOfInstaller> {
+        @Override
+        public String getDisplayName() {
+            return Messages.AnyOfInstaller_DescriptorImpl_displayName();
+        }
+
+        public FormValidation doCheckAttemptsPerInstaller(@QueryParameter String value) {
+            return FormValidation.validatePositiveInteger(value);
+        }
+
+        public FormValidation doCheckAttemptsOfWholeList(@QueryParameter String value) {
+            return FormValidation.validatePositiveInteger(value);
+        }
+    }
+}

--- a/src/main/resources/io/jenkins/plugins/extratoolinstallers/installers/AnyOfInstaller/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/extratoolinstallers/installers/AnyOfInstaller/config.jelly
@@ -1,0 +1,12 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:t="/hudson/tools">
+    <f:property field="installers"/>
+    <f:advanced>
+        <f:entry title="${%Number of times to attempt list of installers}" field="attemptsOfWholeList">
+            <f:textbox clazz="required positive-number" default="1"/>
+        </f:entry>
+        <f:entry title="${%Number of times to attempt each installer before moving on}" field="attemptsPerInstaller">
+            <f:textbox clazz="required positive-number" default="1"/>
+        </f:entry>
+    </f:advanced>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/extratoolinstallers/installers/AnyOfInstaller/help-attemptsOfWholeList.html
+++ b/src/main/resources/io/jenkins/plugins/extratoolinstallers/installers/AnyOfInstaller/help-attemptsOfWholeList.html
@@ -1,0 +1,8 @@
+<p>
+The number of attempts that will be made to loop through the specified list of installers.
+</p>
+<p>
+In the event that no installer succeeds during the first pass through the list, this allows the entire list to be attempted again, up to the limit specified.
+Zero or negative numbers are ignored: If a number less than 1 is specified then the number 1 will be used instead, so the list will always be attempted.
+</p>
+Note that this is cumulative with the "per installer" attempts, so if both are set to 3 then (in the event of repeated failure) an installer may be attempted 9 times.

--- a/src/main/resources/io/jenkins/plugins/extratoolinstallers/installers/AnyOfInstaller/help-attemptsPerInstaller.html
+++ b/src/main/resources/io/jenkins/plugins/extratoolinstallers/installers/AnyOfInstaller/help-attemptsPerInstaller.html
@@ -1,0 +1,8 @@
+<p>
+The number of times each installer is tried, in a row, before the next one is attempted.
+</p>
+<p>
+If this is set to a number that is more than 1 then, in the event that an installer fails, it will will be retried up to the limit specified.
+If a number less than 1 is specified then the number 1 will be used instead, so each installer will be attempted at least once.
+</p>
+Note that this is cumulative with the "whole list" attempts, so if both are set to 3 then (in the event of repeated failure) an installer may be attempted 9 times.

--- a/src/main/resources/io/jenkins/plugins/extratoolinstallers/installers/AnyOfInstaller/help-installers.html
+++ b/src/main/resources/io/jenkins/plugins/extratoolinstallers/installers/AnyOfInstaller/help-installers.html
@@ -1,0 +1,12 @@
+<p>
+A list of one or more installation methods to be attempted in sequence.
+This installer will declare its installation an overall success if any of the methods succeed.
+</p>
+<p>
+The order of installers in the list is the order in which they will be attempted.
+During an installation, any non-applicable installers (e.g. labels not matching) will be silently ignored.
+The remainder will be reported on, including any retries.
+</p>
+<p>
+In the event of a total failure (after all installers and all retries), the last failure exception will be fully logged and the build will fail.
+</p>

--- a/src/main/resources/io/jenkins/plugins/extratoolinstallers/installers/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/extratoolinstallers/installers/Messages.properties
@@ -1,0 +1,10 @@
+AnyOfInstaller.DescriptorImpl.displayName=Try any of ...
+AnyOfInstaller.all_failed=No installation was successful.
+AnyOfInstaller.loops_installers_attempts=[Any of: Loop {0}/{1}, installer {2}/{3} "{4}", attempt {5} of {6}] {7}
+AnyOfInstaller.1loop_installers_attempts=[Any of: Installer {2}/{3} "{4}", attempt {5} of {6}] {7}
+AnyOfInstaller.loops_1installer_attempts=[Any of: Loop {0}/{1}, attempt {5} of {6}] {7}
+AnyOfInstaller.1loop_1installer_attempts=[Any of: Attempt {5} of {6}] {7}
+AnyOfInstaller.loops_installers_1attempt=[Any of: Loop {0}/{1}, installer {2}/{3} "{4}"] {7}
+AnyOfInstaller.1loop_installers_1attempt=[Any of: Installer {2}/{3} "{4}"] {7}
+AnyOfInstaller.loops_1installer_1attempt=[Any of: Loop {0}/{1}] {7}
+AnyOfInstaller.1loop_1installer_1attempt=[Any of] {7}

--- a/src/test/java/io/jenkins/plugins/extratoolinstallers/installers/AnyOfInstallerTest.java
+++ b/src/test/java/io/jenkins/plugins/extratoolinstallers/installers/AnyOfInstallerTest.java
@@ -1,0 +1,426 @@
+package io.jenkins.plugins.extratoolinstallers.installers;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static com.google.common.collect.Lists.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.List;
+
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import com.synopsys.arc.jenkinsci.plugins.extratoolinstallers.utils.ExtraToolInstallersException;
+
+import hudson.FilePath;
+import hudson.model.Node;
+import hudson.model.TaskListener;
+import hudson.tools.InstallSourceProperty;
+import hudson.tools.ToolInstallation;
+import hudson.tools.ToolInstaller;
+
+/** Unit test for the {@link AnyOfInstaller} class. */
+public class AnyOfInstallerTest {
+
+    @Test
+    public void defaultConstructorWhenCalledThenCreatesDefaultInstance() {
+        // Given
+        final int expectedAttemptsOfWholeList = 1;
+        final int expectedAttemptsPerInstaller = 1;
+        final AnyOfInstaller instance = new AnyOfInstaller();
+
+        // When
+        final String actualLabel = instance.getLabel();
+        final InstallSourceProperty actualInstallers = instance.getInstallers();
+        final int actualAttemptsOfWholeList = instance.getAttemptsOfWholeList();
+        final int actualAttemptsPerInstaller = instance.getAttemptsPerInstaller();
+
+        // Then
+        assertThat(actualLabel, nullValue());
+        assertThat(actualInstallers, nullValue());
+        assertThat(actualAttemptsOfWholeList, equalTo(expectedAttemptsOfWholeList));
+        assertThat(actualAttemptsPerInstaller, equalTo(expectedAttemptsPerInstaller));
+    }
+
+    @Test
+    public void setInstallersWhenCalledWhileToolSetThenSetsToolOnInstallers() throws Exception {
+        // Given
+        final TestToolInstaller installer1 = mock(TestToolInstaller.class);
+        final TestToolInstaller installer2 = mock(TestToolInstaller.class);
+        final List<ToolInstaller> installerList = newArrayList(installer1, installer2);
+        final InstallSourceProperty installers = new InstallSourceProperty(installerList);
+        final AnyOfInstaller instance = new AnyOfInstaller();
+        final ToolInstallation mockToolInstallation = mock(ToolInstallation.class);
+        instance.setTool(mockToolInstallation);
+
+        // When
+        instance.setInstallers(installers);
+
+        // Then
+        verify(installer1, times(1)).setTool(mockToolInstallation);
+        verify(installer2, times(1)).setTool(mockToolInstallation);
+    }
+
+    @Test
+    public void getAttemptsPerInstallerGivenZeroNumberThenReturnsOne() {
+        // Given
+        final int expectedAttemptsPerInstaller = 1;
+        final AnyOfInstaller instance = new AnyOfInstaller();
+        instance.setAttemptsPerInstaller(0);
+
+        // When
+        final int actualAttemptsPerInstaller = instance.getAttemptsPerInstaller();
+
+        // Then
+        assertThat(actualAttemptsPerInstaller, equalTo(expectedAttemptsPerInstaller));
+    }
+
+    @Test
+    public void getAttemptsPerInstallerGivenNegativeNumberThenReturnsOne() {
+        // Given
+        final int expectedAttemptsPerInstaller = 1;
+        final AnyOfInstaller instance = new AnyOfInstaller();
+        instance.setAttemptsPerInstaller(-1234);
+
+        // When
+        final int actualAttemptsPerInstaller = instance.getAttemptsPerInstaller();
+
+        // Then
+        assertThat(actualAttemptsPerInstaller, equalTo(expectedAttemptsPerInstaller));
+    }
+
+    @Test
+    public void getAttemptsOfWholeListGivenZeroNumberThenReturnsOne() {
+        // Given
+        final int expectedAttemptsOfWholeList = 1;
+        final AnyOfInstaller instance = new AnyOfInstaller();
+        instance.setAttemptsOfWholeList(0);
+
+        // When
+        final int actualAttemptsOfWholeList = instance.getAttemptsOfWholeList();
+
+        // Then
+        assertThat(actualAttemptsOfWholeList, equalTo(expectedAttemptsOfWholeList));
+    }
+
+    @Test
+    public void getAttemptsOfWholeListGivenNegativeNumberThenReturnsOne() {
+        // Given
+        final int expectedAttemptsOfWholeList = 1;
+        final AnyOfInstaller instance = new AnyOfInstaller();
+        instance.setAttemptsOfWholeList(-1234);
+
+        // When
+        final int actualAttemptsOfWholeList = instance.getAttemptsOfWholeList();
+
+        // Then
+        assertThat(actualAttemptsOfWholeList, equalTo(expectedAttemptsOfWholeList));
+    }
+
+    @Test
+    public void setToolWhenCalledNoInstancesThenJustSetsTool() throws Exception {
+        // Given
+        final AnyOfInstaller instance = new AnyOfInstaller();
+        final ToolInstallation mockToolInstallation = mock(ToolInstallation.class);
+
+        // When
+        instance.setTool(mockToolInstallation);
+
+        // Then
+        // expect no exception to be thrown
+    }
+
+    @Test
+    public void setToolWhenCalledWithInstancesThenSetsToolOnThoseAsWell() throws Exception {
+        // Given
+        final TestToolInstaller installer1 = mock(TestToolInstaller.class);
+        final TestToolInstaller installer2 = mock(TestToolInstaller.class);
+        final List<ToolInstaller> installerList = newArrayList(installer1, installer2);
+        final InstallSourceProperty installers = new InstallSourceProperty(installerList);
+        final AnyOfInstaller instance = new AnyOfInstaller();
+        instance.setInstallers(installers);
+        final ToolInstallation mockToolInstallation = mock(ToolInstallation.class);
+
+        // When
+        instance.setTool(mockToolInstallation);
+
+        // Then
+        verify(installer1, times(1)).setTool(mockToolInstallation);
+        verify(installer2, times(1)).setTool(mockToolInstallation);
+    }
+
+    @Test
+    public void appliesToGivenNoInstallersThenReturnsFalse() {
+        // Given
+        final AnyOfInstaller instance = new AnyOfInstaller();
+        final Node mockNode = mock(Node.class);
+
+        // When
+        final boolean actual = instance.appliesTo(mockNode);
+
+        // Then
+        assertThat(actual, equalTo(false));
+    }
+
+    @Test
+    public void appliesToGivenNoApplicableInstallersThenReturnsFalse() throws Exception {
+        // Given
+        final Node mockNode = mock(Node.class);
+        final ToolInstaller installer1 = mock(ToolInstaller.class);
+        final ToolInstaller installer2 = mock(ToolInstaller.class);
+        when(installer1.appliesTo(mockNode)).thenReturn(false);
+        when(installer2.appliesTo(mockNode)).thenReturn(false);
+        final List<ToolInstaller> installerList = newArrayList(installer1, installer2);
+        final InstallSourceProperty installers = new InstallSourceProperty(installerList);
+        final AnyOfInstaller instance = new AnyOfInstaller();
+        instance.setInstallers(installers);
+
+        // When
+        final boolean actual = instance.appliesTo(mockNode);
+
+        // Then
+        assertThat(actual, equalTo(false));
+    }
+
+    @Test
+    public void appliesToGivenOneApplicableInstallerThenReturnsTrue() throws Exception {
+        // Given
+        final Node mockNode = mock(Node.class);
+        final ToolInstaller installer1 = mock(ToolInstaller.class);
+        final ToolInstaller installer2 = mock(ToolInstaller.class);
+        when(installer1.appliesTo(mockNode)).thenReturn(false);
+        when(installer2.appliesTo(mockNode)).thenReturn(true);
+        final List<ToolInstaller> installerList = newArrayList(installer1, installer2);
+        final InstallSourceProperty installers = new InstallSourceProperty(installerList);
+        final AnyOfInstaller instance = new AnyOfInstaller();
+        instance.setInstallers(installers);
+
+        // When
+        final boolean actual = instance.appliesTo(mockNode);
+
+        // Then
+        assertThat(actual, equalTo(true));
+    }
+
+    @Test
+    public void performInstallationGiven1Loop1FailingInstaller1AttemptThenFails() throws Exception {
+        // Given
+        final Node mockNode = mock(Node.class);
+        final ToolInstallation mockTool = mock(ToolInstallation.class);
+        final List<String> actualLogRecord = newArrayList();
+        final TaskListener mockLog = mockTaskListener(actualLogRecord);
+        final String installerDisplayName = "MyInstaller";
+        final ToolInstaller installer = mockInstaller(installerDisplayName, mockNode);
+        final PretendInstallerFailureException expectedCause = new PretendInstallerFailureException();
+        when(installer.performInstallation(mockTool, mockNode, mockLog)).thenThrow(expectedCause);
+        final List<ToolInstaller> installerList = newArrayList(installer);
+        final InstallSourceProperty installers = new InstallSourceProperty(installerList);
+        final AnyOfInstaller instance = new AnyOfInstaller();
+        instance.setInstallers(installers);
+        final List<String> expectedLogRecord = newArrayList(Messages.AnyOfInstaller_1loop_1installer_1attempt(1, 1, 1,
+                1, installerDisplayName, 1, 1, expectedCause));
+
+        // When
+        try {
+            instance.performInstallation(mockTool, mockNode, mockLog);
+            fail("Expected " + ExtraToolInstallersException.class);
+        } catch (ExtraToolInstallersException ex) {
+            // Then
+            assertThat(ex.getCause(), sameInstance(expectedCause));
+        }
+        assertThat(actualLogRecord, equalTo(expectedLogRecord));
+        verify(installer, times(1)).performInstallation(mockTool, mockNode, mockLog);
+    }
+
+    @Test
+    public void performInstallationGivenOneLoopAFailingInapplicableInstallerAndAPassingApplicableInstallerOneAttemptThenPasses()
+            throws Exception {
+        // Given
+        final Node mockNode = mock(Node.class);
+        final ToolInstallation mockTool = mock(ToolInstallation.class);
+        final List<String> actualLogRecord = newArrayList();
+        final TaskListener mockLog = mockTaskListener(actualLogRecord);
+        final String workingInstallerDisplayName = "WorkingInstaller";
+        final String failingInstallerDisplayName = "FailingInapplicableInstaller";
+        final ToolInstaller applicableInstaller = mockInstaller(workingInstallerDisplayName, mockNode);
+        final ToolInstaller inapplicableInstaller = mockInstaller(failingInstallerDisplayName);
+        when(inapplicableInstaller.performInstallation(mockTool, mockNode, mockLog))
+                .thenThrow(new PretendInstallerFailureException());
+        final FilePath expected = stubFilePath();
+        when(applicableInstaller.performInstallation(mockTool, mockNode, mockLog)).thenReturn(expected);
+        final List<ToolInstaller> installerList = newArrayList(inapplicableInstaller, applicableInstaller);
+        final InstallSourceProperty installers = new InstallSourceProperty(installerList);
+        final AnyOfInstaller instance = new AnyOfInstaller();
+        instance.setInstallers(installers);
+        final List<String> expectedLogRecord = newArrayList();
+
+        // When
+        final FilePath actual = instance.performInstallation(mockTool, mockNode, mockLog);
+
+        // Then
+        assertThat(actual, equalTo(expected));
+        assertThat(actualLogRecord, equalTo(expectedLogRecord));
+        verify(applicableInstaller, times(1)).performInstallation(mockTool, mockNode, mockLog);
+        verify(inapplicableInstaller, times(0)).performInstallation(mockTool, mockNode, mockLog);
+    }
+
+    @Test
+    public void performInstallationGivenTwoLoopsFourUnreliableInstallersThreeAttemptsThenEventuallyPasses()
+            throws Exception {
+        // Given
+        final Node mockNode = mock(Node.class);
+        final ToolInstallation mockTool = mock(ToolInstallation.class);
+        final List<String> actualLogRecord = newArrayList();
+        final TaskListener mockLog = mockTaskListener(actualLogRecord);
+        final String inapplicableInstallerDisplayName1 = "ShouldNotAppearAsThisIsNotApplicableToNode1";
+        final String inapplicableInstallerDisplayName2 = "ShouldNotAppearAsThisIsNotApplicableToNode2";
+        final ToolInstaller inapplicableInstaller1 = mockInstaller(inapplicableInstallerDisplayName1);
+        final ToolInstaller inapplicableInstaller2 = mockInstaller(inapplicableInstallerDisplayName2);
+        final String failingInstallerName = "AlwaysFails";
+        final PretendInstallerFailureException failingInstallerCause1 = new PretendInstallerFailureException(
+                "failingInstallerCause1");
+        final PretendInstallerFailureException failingInstallerCause2 = new PretendInstallerFailureException(
+                "failingInstallerCause2");
+        final PretendInstallerFailureException failingInstallerCause3 = new PretendInstallerFailureException(
+                "failingInstallerCause3");
+        final PretendInstallerFailureException failingInstallerCause4 = new PretendInstallerFailureException(
+                "failingInstallerCause4");
+        final PretendInstallerFailureException failingInstallerCause5 = new PretendInstallerFailureException(
+                "failingInstallerCause5");
+        final PretendInstallerFailureException failingInstallerCause6 = new PretendInstallerFailureException(
+                "failingInstallerCause6");
+        final ToolInstaller failingInstaller = mockInstaller(failingInstallerName, mockNode);
+        when(failingInstaller.performInstallation(mockTool, mockNode, mockLog)).thenThrow(failingInstallerCause1,
+                failingInstallerCause2, failingInstallerCause3, failingInstallerCause4, failingInstallerCause5,
+                failingInstallerCause6);
+        final String unreliableInstallerName = "FailsFirst4TimesThenPasses";
+        final FilePath expected = stubFilePath();
+        final PretendInstallerFailureException unreliableInstallerCause1 = new PretendInstallerFailureException(
+                "unreliableInstallerCause1");
+        final PretendInstallerFailureException unreliableInstallerCause2 = new PretendInstallerFailureException(
+                "unreliableInstallerCause2");
+        final PretendInstallerFailureException unreliableInstallerCause3 = new PretendInstallerFailureException(
+                "unreliableInstallerCause3");
+        final PretendInstallerFailureException unreliableInstallerCause4 = new PretendInstallerFailureException(
+                "unreliableInstallerCause4");
+        final ToolInstaller unreliableInstaller = mockInstaller(unreliableInstallerName, mockNode);
+        when(unreliableInstaller.performInstallation(mockTool, mockNode, mockLog)).thenThrow(unreliableInstallerCause1,
+                unreliableInstallerCause2, unreliableInstallerCause3, unreliableInstallerCause4).thenReturn(expected);
+        final List<ToolInstaller> installerList = newArrayList(inapplicableInstaller1, failingInstaller,
+                inapplicableInstaller2, unreliableInstaller);
+        final int failingInstallerIndex = 2;
+        final int unreliableInstallerIndex = 4;
+        final InstallSourceProperty installers = new InstallSourceProperty(installerList);
+        final AnyOfInstaller instance = new AnyOfInstaller();
+        instance.setInstallers(installers);
+        final int loops = 2;
+        final int tries = 3;
+        final int insts = installerList.size();
+        instance.setAttemptsOfWholeList(loops);
+        instance.setAttemptsPerInstaller(tries);
+        final List<String> expectedLogRecord = newArrayList(
+                Messages.AnyOfInstaller_loops_installers_attempts(1, loops, failingInstallerIndex, insts,
+                        failingInstallerName, 1, tries, failingInstallerCause1),
+                Messages.AnyOfInstaller_loops_installers_attempts(1, loops, failingInstallerIndex, insts,
+                        failingInstallerName, 2, tries, failingInstallerCause2),
+                Messages.AnyOfInstaller_loops_installers_attempts(1, loops, failingInstallerIndex, insts,
+                        failingInstallerName, 3, tries, failingInstallerCause3),
+                Messages.AnyOfInstaller_loops_installers_attempts(1, loops, unreliableInstallerIndex, insts,
+                        unreliableInstallerName, 1, tries, unreliableInstallerCause1),
+                Messages.AnyOfInstaller_loops_installers_attempts(1, loops, unreliableInstallerIndex, insts,
+                        unreliableInstallerName, 2, tries, unreliableInstallerCause2),
+                Messages.AnyOfInstaller_loops_installers_attempts(1, loops, unreliableInstallerIndex, insts,
+                        unreliableInstallerName, 3, tries, unreliableInstallerCause3),
+                Messages.AnyOfInstaller_loops_installers_attempts(2, loops, failingInstallerIndex, insts,
+                        failingInstallerName, 1, tries, failingInstallerCause4),
+                Messages.AnyOfInstaller_loops_installers_attempts(2, loops, failingInstallerIndex, insts,
+                        failingInstallerName, 2, tries, failingInstallerCause5),
+                Messages.AnyOfInstaller_loops_installers_attempts(2, loops, failingInstallerIndex, insts,
+                        failingInstallerName, 3, tries, failingInstallerCause6),
+                Messages.AnyOfInstaller_loops_installers_attempts(2, loops, unreliableInstallerIndex, insts,
+                        unreliableInstallerName, 1, tries, unreliableInstallerCause4));
+
+        // When
+        final FilePath actual = instance.performInstallation(mockTool, mockNode, mockLog);
+
+        // Then
+        assertThat(actual, equalTo(expected));
+        assertThat(actualLogRecord, equalTo(expectedLogRecord));
+        verify(failingInstaller, times(6)).performInstallation(mockTool, mockNode, mockLog);
+        verify(unreliableInstaller, times(5)).performInstallation(mockTool, mockNode, mockLog);
+        verify(inapplicableInstaller1, times(0)).performInstallation(mockTool, mockNode, mockLog);
+        verify(inapplicableInstaller2, times(0)).performInstallation(mockTool, mockNode, mockLog);
+    }
+
+    /////////////////////////////////////////////////////////////////
+    // Test utility code.
+    /////////////////////////////////////////////////////////////////
+
+    /**
+     * Creates a {@link FilePath} we can return from a successfull installation.
+     */
+    private static FilePath stubFilePath() {
+        return new FilePath(new File("/"));
+    }
+
+    /**
+     * Creates a {@link ToolInstaller} with a given name whose
+     * {@link ToolInstaller#appliesTo(Node)} answers "true" to the specified
+     * nodes.
+     */
+    private static ToolInstaller mockInstaller(String displayName, Node... nodesThisAppliesTo) {
+        // use deep stub to avoid generic type code warnings
+        final ToolInstaller ti = mock(ToolInstaller.class, withSettings().defaultAnswer(RETURNS_DEEP_STUBS));
+        when(ti.getDescriptor().getDisplayName()).thenReturn(displayName);
+        for (final Node node : nodesThisAppliesTo) {
+            when(ti.appliesTo(node)).thenReturn(true);
+        }
+        return ti;
+    }
+
+    /** Creates a {@link TaskListener} that records everything printed to it. */
+    private static TaskListener mockTaskListener(List<String> whereToRecord) {
+        final PrintStream ps = mock(PrintStream.class);
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                final Object[] args = invocation.getArguments();
+                final String arg = (String) args[0];
+                whereToRecord.add(arg);
+                return null;
+            }
+        }).when(ps).println(anyString());
+        final TaskListener tl = mock(TaskListener.class);
+        when(tl.getLogger()).thenReturn(ps);
+        return tl;
+    }
+
+    /** Makes {@link #setTool(ToolInstallation)} visible to this test. */
+    private static abstract class TestToolInstaller extends ToolInstaller {
+        public TestToolInstaller(String label) {
+            super(label);
+        }
+
+        @Override
+        public void setTool(ToolInstallation t) {
+            super.setTool(t);
+        }
+    }
+
+    /** Used to test installation failures. */
+    private static class PretendInstallerFailureException extends IOException {
+        private static final long serialVersionUID = 1L;
+
+        PretendInstallerFailureException() {
+            super();
+        }
+
+        PretendInstallerFailureException(String message) {
+            super(message);
+        }
+    }
+}


### PR DESCRIPTION
New installation method that tries (and optionally retries) any (all applicable) installers that it contains.
This allows Jenkins admins to configure custom tools etc to try downloading/installing from multiple different servers and thus cope if the first choice server goes offline.