### PR TITLE
Added Authenticated download-and-unzip installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Features
   * `@Deprecated`. Jenkins Core supports such installer since 1.549 (see [JENKINS-21202](https://issues.jenkins-ci.org/browse/JENKINS-21202))
 * "Install from specified folder" - setup without any actions (ex, "installation" from a shared directory)
 * "Skip or fail installation" - prints warnings during the installation and/or fails the installation
+* "Authenticated download and unpack of a zip/tar.gz.
 
 
 License

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,16 @@
         </developer>
     </developers>
 
+    <dependencies>
+        <!-- Main Dependencies -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <!-- Earliest version that supports c:select checkMethod="post" is 2.1.15, dated Sep 6 2017. -->
+            <version>2.1.15</version>
+        </dependency>
+    </dependencies>
+
     <scm>
         <connection>scm:git:ssh://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/${project.artifactId}-plugin.git</developerConnection>

--- a/src/main/java/io/jenkins/plugins/extratoolinstallers/installers/AuthenticatedDownloadCallable.java
+++ b/src/main/java/io/jenkins/plugins/extratoolinstallers/installers/AuthenticatedDownloadCallable.java
@@ -1,0 +1,317 @@
+package io.jenkins.plugins.extratoolinstallers.installers;
+
+import static hudson.FilePath.TarCompression.GZIP;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.apache.commons.httpclient.Header;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpMethodBase;
+import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.apache.commons.httpclient.UsernamePasswordCredentials;
+import org.apache.commons.httpclient.auth.AuthScope;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.httpclient.methods.HeadMethod;
+import org.apache.commons.httpclient.util.DateParseException;
+import org.apache.commons.httpclient.util.DateUtil;
+import org.apache.commons.io.input.CountingInputStream;
+
+import hudson.FilePath;
+import hudson.model.TaskListener;
+import hudson.remoting.VirtualChannel;
+import jenkins.MasterToSlaveFileCallable;
+
+/**
+ * Utility class that can download a zip/tar.gz and unpack it.
+ */
+class AuthenticatedDownloadCallable extends MasterToSlaveFileCallable<Date> {
+    private static final long serialVersionUID = 1L;
+    @Nonnull
+    private final URI uri;
+    @CheckForNull
+    private final String usernameOrNull;
+    @CheckForNull
+    private final String passwordOrNull;
+    @CheckForNull
+    private final Long timestampOfLocalContents;
+    @Nonnull
+    private final String nodeName;
+    @CheckForNull
+    private final TaskListener logOrNull;
+
+    /**
+     * Passed to {@link FilePath#act(hudson.FilePath.FileCallable)} in order to
+     * run
+     * {@link #doDownload(GetMethod, FilePath, TaskListener, URI, String, String)}
+     * on a remote node.
+     * 
+     * @param uri
+     *            What to download.
+     * @param usernameOrNull
+     *            Username to authenticate as, or null for an anonymous
+     *            download.
+     * @param passwordOrNull
+     *            Password for the username, or null for no password.
+     * @param timestampOfLocalContents
+     *            null for an unconditional download, else the timestamp of what
+     *            we have locally.
+     * @param nodeName
+     *            The name of the node we are downloading onto. Used for logging
+     *            purposes only.
+     * @param logOrNull
+     *            Where to log build progress. Can be null to suppress the
+     *            normal running commentary.
+     */
+    AuthenticatedDownloadCallable(@Nonnull URI uri, @CheckForNull String usernameOrNull,
+            @CheckForNull String passwordOrNull, @CheckForNull Long timestampOfLocalContents, @Nonnull String nodeName,
+            @CheckForNull TaskListener logOrNull) {
+        this.uri = uri;
+        this.usernameOrNull = usernameOrNull;
+        this.passwordOrNull = passwordOrNull;
+        this.timestampOfLocalContents = timestampOfLocalContents;
+        this.nodeName = nodeName;
+        this.logOrNull = logOrNull;
+    }
+
+    public Date invoke(@Nonnull File d, VirtualChannel channel) throws IOException, InterruptedException {
+        final FilePath whereToDownloadTo = new FilePath(d);
+        return downloadAndUnpack(uri, usernameOrNull, passwordOrNull, timestampOfLocalContents, nodeName,
+                whereToDownloadTo, logOrNull);
+    }
+
+    /**
+     * Does the download-and-unpack if necessary. The download will be skipped
+     * if the remote contents is no newer than the
+     * <code>timestampOfLocalContents</code> says. The download will also be
+     * skipped if <code>whereToDownloadToOrNull</code> is null.
+     * 
+     * @param uri
+     *            What to download.
+     * @param usernameOrNull
+     *            Username to authenticate as, or null for an anonymous
+     *            download.
+     * @param passwordOrNull
+     *            Password for the username, or null for no password.
+     * @param timestampOfLocalContents
+     *            null for an unconditional download, else the timestamp of what
+     *            we have locally.
+     * @param nodeName
+     *            The name of the node we are downloading onto. Used for logging
+     *            purposes only. Ignored if <code>log</code> is null.
+     * @param whereToDownloadToOrNull
+     *            The folder where we'll unpack the contents into. Can be null
+     *            if all we're doing is testing our ability to contact the
+     *            remote server and don't want to do the download for real.
+     * @param logOrNull
+     *            Where to log build progress. Can be null to suppress the
+     *            normal running commentary.
+     * @return last-modified date of the remote contents if the contents was
+     *         downloaded. null if we did not download but did not error.
+     * @throws HttpGetException
+     *             if we got a bad response from the webserver.
+     * @throws IOException
+     *             if we failed to download for other reasons.
+     * @throws InterruptedException
+     *             if we were interrupted.
+     */
+    static Date downloadAndUnpack(@Nonnull final URI uri, @CheckForNull final String usernameOrNull,
+            @CheckForNull final String passwordOrNull, @CheckForNull final Long timestampOfLocalContents,
+            @Nonnull final String nodeName, @CheckForNull final FilePath whereToDownloadToOrNull,
+            @CheckForNull final TaskListener logOrNull) throws IOException, InterruptedException {
+        final HttpClient client = new HttpClient();
+        final HttpMethodBase httpRequest;
+        if (whereToDownloadToOrNull == null) {
+            // we're only validating the URL & credentials.
+            httpRequest = new HeadMethod();
+        } else {
+            httpRequest = new GetMethod();
+        }
+        httpRequest.setURI(uri);
+        if (usernameOrNull != null) {
+            setAuthentication(usernameOrNull, passwordOrNull, client, httpRequest);
+        }
+        httpRequest.setFollowRedirects(true);
+        final Date dateOfLocalContents = timestampOfLocalContents == null ? null : new Date(timestampOfLocalContents);
+        final String ifModifiedSince = "If-Modified-Since";
+        final String lastModified = "Last-Modified";
+        if (dateOfLocalContents != null) {
+            final String timestampAsString = DateUtil.formatDate(dateOfLocalContents);
+            final Header header = new Header(ifModifiedSince, timestampAsString);
+            httpRequest.addRequestHeader(header);
+        }
+        try {
+            final int status = client.executeMethod(httpRequest);
+            /*
+             * if (logOrNull != null) { final String msg = "HTTP GET of " + uri
+             * + " with request headers of " +
+             * java.util.Arrays.toString(httpGet.getRequestHeaders()) +
+             * " returned response code " + status + " and response headers of "
+             * + java.util.Arrays.toString(httpGet.getResponseHeaders());
+             * logOrNull.getLogger().println(msg); }
+             */
+            final Date dateOfRemoteContents;
+            switch (status) {
+                case HttpStatus.SC_NOT_MODIFIED :
+                    dateOfRemoteContents = null;
+                    break;
+                case HttpStatus.SC_OK :
+                    final Header lastModifiedResponseHeader = httpRequest.getResponseHeader(lastModified);
+                    if (lastModifiedResponseHeader == null) {
+                        throw new HttpGetException(uri.toString(), usernameOrNull,
+                                "due to missing " + lastModified + " header value.");
+                    }
+                    final String lastModifiedStringValue = lastModifiedResponseHeader.getValue();
+                    try {
+                        final Date dateFromRemoteServer = DateUtil.parseDate(lastModifiedStringValue);
+                        if (dateOfLocalContents == null || dateFromRemoteServer.after(dateOfLocalContents)) {
+                            dateOfRemoteContents = dateFromRemoteServer;
+                        } else {
+                            dateOfRemoteContents = null;
+                        }
+                    } catch (DateParseException ex) {
+                        throw new HttpGetException(uri.toString(), usernameOrNull, "due to invalid " + lastModified
+                                + " header value, \"" + lastModifiedStringValue + "\".", ex);
+                    }
+                    break;
+                default :
+                    throw new HttpGetException(uri.toString(), usernameOrNull, status);
+            }
+            if (whereToDownloadToOrNull != null) {
+                if (dateOfRemoteContents == null) {
+                    // we don't want to do the download after all.
+                    skipDownload(whereToDownloadToOrNull, logOrNull, uri, nodeName);
+                    httpRequest.abort();
+                    return null;
+                } else {
+                    doDownload(httpRequest, whereToDownloadToOrNull, logOrNull, uri, usernameOrNull, nodeName);
+                }
+            }
+            return dateOfRemoteContents;
+        } finally {
+            httpRequest.releaseConnection();
+        }
+    }
+
+    private static void setAuthentication(@CheckForNull final String usernameOrNull,
+            @CheckForNull final String passwordOrNull, @Nonnull final HttpClient client,
+            @Nonnull final HttpMethodBase httpRequest) throws URIException {
+        final UsernamePasswordCredentials httpClientCredentials = new UsernamePasswordCredentials(usernameOrNull,
+                passwordOrNull);
+        final String host = httpRequest.getURI().getHost();
+        final AuthScope scope = new AuthScope(host, -1);
+        client.getState().setCredentials(scope, httpClientCredentials);
+        httpRequest.setDoAuthentication(true);
+        client.getParams().setAuthenticationPreemptive(true);
+    }
+
+    private static void skipDownload(@Nonnull final FilePath whereToDownloadTo,
+            @CheckForNull final TaskListener logOrNull, @Nonnull final URI uri, @Nonnull final String nodeName) {
+        if (logOrNull != null) {
+            final String folder = whereToDownloadTo.getRemote();
+            final String msg = Messages.AuthenticatedZipExtractionInstaller_download_skipped(uri, folder, nodeName);
+            logOrNull.getLogger().println(msg);
+        }
+    }
+
+    private static void doDownload(@Nonnull final HttpMethodBase httpGet, @Nonnull final FilePath whereToDownloadTo,
+            @CheckForNull final TaskListener logOrNull, @Nonnull final URI uri,
+            @CheckForNull final String usernameOrNull, @Nonnull final String nodeName)
+            throws IOException, InterruptedException, URIException {
+        if (whereToDownloadTo.exists()) {
+            whereToDownloadTo.deleteContents();
+            if (logOrNull != null) {
+                final String folder = whereToDownloadTo.getRemote();
+                final String msg = usernameOrNull == null
+                        ? Messages.AuthenticatedZipExtractionInstaller_anonymous_download_newer(uri, folder, nodeName)
+                        : Messages.AuthenticatedZipExtractionInstaller_authenticated_download_newer(uri, usernameOrNull,
+                                folder, nodeName);
+                logOrNull.getLogger().println(msg);
+            }
+        } else {
+            whereToDownloadTo.mkdirs();
+            if (logOrNull != null) {
+                final String folder = whereToDownloadTo.getRemote();
+                final String msg = usernameOrNull == null
+                        ? Messages.AuthenticatedZipExtractionInstaller_anonymous_download_new(uri, folder, nodeName)
+                        : Messages.AuthenticatedZipExtractionInstaller_authenticated_download_new(uri, usernameOrNull,
+                                folder, nodeName);
+                logOrNull.getLogger().println(msg);
+            }
+        }
+        final boolean isZipNotGzip = uri.getPath().endsWith(".zip");
+        final long expectedContentLength = httpGet.getResponseContentLength();
+        try (final CountingInputStream cis = new CountingInputStream(httpGet.getResponseBodyAsStream())) {
+            try {
+                if (isZipNotGzip) {
+                    whereToDownloadTo.unzipFrom(cis);
+                } else {
+                    whereToDownloadTo.untarFrom(cis, GZIP);
+                }
+            } catch (IOException ex) {
+                final String msg = Messages.AuthenticatedZipExtractionInstaller_unpack_failed(uri, cis.getByteCount(),
+                        expectedContentLength);
+                throw new IOException(msg, ex);
+            }
+        }
+    }
+
+    /**
+     * Indicates that we were able to talk to the server but we did not like
+     * what it said.
+     */
+    static class HttpGetException extends IOException {
+        private static final long serialVersionUID = 1L;
+        @Nonnull
+        private final String uri;
+        @CheckForNull
+        private final String usernameOrNull;
+        @CheckForNull
+        private final Integer httpStatusCodeOrNull;
+
+        private HttpGetException(@Nonnull final String uri, @CheckForNull final String usernameOrNull,
+                @CheckForNull Integer httpStatusCodeOrNull, @Nonnull final String reason, @Nullable Throwable cause) {
+            super((usernameOrNull == null ? "Anonymous" : "Authenticated") + " HTTP GET of " + uri
+                    + (usernameOrNull == null ? "" : (" as " + usernameOrNull)) + " failed, " + reason, cause);
+            this.uri = uri;
+            this.usernameOrNull = usernameOrNull;
+            this.httpStatusCodeOrNull = httpStatusCodeOrNull;
+        }
+
+        HttpGetException(@Nonnull final String uri, @CheckForNull final String usernameOrNull, int httpStatusCode) {
+            this(uri, usernameOrNull, httpStatusCode,
+                    httpStatusCode + " (" + HttpStatus.getStatusText(httpStatusCode) + ")", null);
+        }
+
+        HttpGetException(@Nonnull final String uri, @CheckForNull final String usernameOrNull, @Nonnull String reason,
+                @Nullable Throwable cause) {
+            this(uri, usernameOrNull, null, reason, cause);
+        }
+
+        HttpGetException(@Nonnull final String uri, @CheckForNull final String usernameOrNull, @Nonnull String reason) {
+            this(uri, usernameOrNull, null, reason, null);
+        }
+
+        @Nonnull
+        public String getUri() {
+            return uri;
+        }
+
+        @CheckForNull
+        public String getUsername() {
+            return usernameOrNull;
+        }
+
+        @CheckForNull
+        public Integer getHttpStatusCode() {
+            return httpStatusCodeOrNull;
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/extratoolinstallers/installers/AuthenticatedZipExtractionInstaller.java
+++ b/src/main/java/io/jenkins/plugins/extratoolinstallers/installers/AuthenticatedZipExtractionInstaller.java
@@ -516,8 +516,9 @@ public class AuthenticatedZipExtractionInstaller extends ToolInstaller {
                 AuthenticatedDownloadCallable.downloadAndUnpack(uri, usernameOrNull, passwordOrNull,
                         timestampOfLocalContents, nodeName, whereToDownloadToOrNull, log);
             } catch (AuthenticatedDownloadCallable.HttpGetException ex) {
-                if (ex.getHttpStatusCode() != null) {
-                    final int httpStatusCode = ex.getHttpStatusCode().intValue();
+                final Integer httpStatusCodeOrNull = ex.getHttpStatusCode();
+                if (httpStatusCodeOrNull != null) {
+                    final int httpStatusCode = httpStatusCodeOrNull.intValue();
                     if (httpStatusCode == HttpStatus.SC_UNAUTHORIZED) {
                         if (usernameOrNull == null) {
                             return credentialProblem(checkUrl, FormValidation.error(ex,

--- a/src/main/java/io/jenkins/plugins/extratoolinstallers/installers/AuthenticatedZipExtractionInstaller.java
+++ b/src/main/java/io/jenkins/plugins/extratoolinstallers/installers/AuthenticatedZipExtractionInstaller.java
@@ -1,0 +1,558 @@
+package io.jenkins.plugins.extratoolinstallers.installers;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.interceptor.RequirePOST;
+
+import com.cloudbees.plugins.credentials.CredentialsMatcher;
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.PasswordCredentials;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import com.cloudbees.plugins.credentials.common.UsernameCredentials;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import com.cloudbees.plugins.credentials.domains.HostnameRequirement;
+import com.synopsys.arc.jenkinsci.plugins.extratoolinstallers.utils.ExtraToolInstallersException;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Functions;
+import hudson.Util;
+import hudson.model.ItemGroup;
+import hudson.model.Node;
+import hudson.model.TaskListener;
+import hudson.remoting.VirtualChannel;
+import hudson.security.ACL;
+import hudson.tools.ToolInstallation;
+import hudson.tools.ToolInstaller;
+import hudson.tools.ToolInstallerDescriptor;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+import hudson.util.Secret;
+import jenkins.MasterToSlaveFileCallable;
+import jenkins.model.Jenkins;
+
+/**
+ * A {@link ToolInstaller} that downloads a zip or tar.gz and unpacks it in
+ * order to install a tool. If the tool is already present, it will only be
+ * re-downloaded/re-unpacked if the URL is newer than the existing content. The
+ * download supports HTTP basic authentication.
+ */
+public class AuthenticatedZipExtractionInstaller extends ToolInstaller {
+    @CheckForNull
+    private String url;
+
+    @CheckForNull
+    private String credentialsId;
+
+    @CheckForNull
+    private String subdir;
+
+    @DataBoundConstructor
+    public AuthenticatedZipExtractionInstaller(String label) {
+        super(label);
+    }
+
+    /**
+     * URL of a zip/tar.gz file which should be downloaded and unpacked if the
+     * tool is missing or out of date.
+     * 
+     * @return URL, or null if none has been set.
+     */
+    @CheckForNull
+    public String getUrl() {
+        return Util.fixEmpty(url);
+    }
+
+    /**
+     * Sets {@link #getUrl()}.
+     * 
+     * @param url
+     *            New value.
+     */
+    @DataBoundSetter
+    public void setUrl(@Nullable String url) {
+        this.url = Util.fixEmpty(url);
+    }
+
+    /**
+     * ID of the credentials to use when doing the download.
+     * 
+     * @return The credentials ID, or null if none has been set.
+     */
+    @CheckForNull
+    public String getCredentialsId() {
+        return Util.fixEmpty(credentialsId);
+    }
+
+    /**
+     * Sets {@link #getCredentialsId()}.
+     * 
+     * @param credentialsId
+     *            New value.
+     */
+    @DataBoundSetter
+    public void setCredentialsId(@Nullable String credentialsId) {
+        this.credentialsId = Util.fixEmpty(credentialsId);
+    }
+
+    /**
+     * Subdirectory within the zip/tar.gz where the tool's binaries are located.
+     * It is this folder that's added to the path (etc). Can be null/empty if
+     * the binaries are at the base of the zip/tar.gz.
+     * 
+     * @return The subdirectory, or null if no subdirectory has been set.
+     */
+    @CheckForNull
+    public String getSubdir() {
+        return Util.fixEmpty(subdir);
+    }
+
+    /**
+     * Sets {@link #getSubdir()}.
+     * 
+     * @param subdir
+     *            New value.
+     */
+    @DataBoundSetter
+    public void setSubdir(@Nullable String subdir) {
+        this.subdir = Util.fixEmpty(subdir);
+    }
+
+    @Override
+    public FilePath performInstallation(@Nonnull ToolInstallation tool, @Nonnull Node node,
+            @CheckForNull TaskListener log) throws IOException, InterruptedException {
+        final String url = getUrl();
+        final URI uri;
+        final String urlHost;
+        try {
+            uri = new URI(url, false);
+            urlHost = uri.getHost();
+        } catch (URIException ex) {
+            throw new ExtraToolInstallersException(this, Messages.AuthenticatedZipExtractionInstaller_malformed_url(),
+                    ex);
+        }
+        final StandardCredentials credentialsOrNull = lookupConfiguredCredentials(urlHost);
+        final String usernameOrNull;
+        final String passwordOrNull;
+        if (credentialsOrNull == null) {
+            usernameOrNull = null;
+            passwordOrNull = null;
+        } else {
+            usernameOrNull = getUsernameFromCredentials(credentialsOrNull);
+            passwordOrNull = getPasswordFromCredentials(credentialsOrNull);
+        }
+        final FilePath dir = preferredLocation(tool, node);
+        final Long timestampOfLocalContents;
+        final FilePath timestamp = dir.child(".timestamp");
+        if (timestamp.exists()) {
+            final long lastModified = timestamp.lastModified();
+            timestampOfLocalContents = Long.valueOf(lastModified);
+        } else {
+            timestampOfLocalContents = null;
+        }
+        final String nodeName = node.getDisplayName();
+        /*
+         * if (log != null) { log.getLogger()
+         * .println(this.getClass().getSimpleName() + ": credentialsId=" +
+         * credentialsIdOrNull + ", user=" + usernameOrNull + ", pwd=" +
+         * passwordOrNull + ", uri=" + uri.toString() +
+         * ", timestampOfLocalContents=" + timestampOfLocalContents +
+         * ", nodeName=" + nodeName); }
+         */
+        final Date timestampOfRemoteResource = downloadOnNodeWithFallbackToMaster(uri, timestampOfLocalContents,
+                usernameOrNull, passwordOrNull, nodeName, dir, log);
+        if (timestampOfRemoteResource != null) {
+            dir.act(new ChmodRecAPlusX());
+            timestamp.touch(timestampOfRemoteResource.getTime());
+        }
+        final String subdirOrNull = getSubdir();
+        if (subdirOrNull == null) {
+            return dir;
+        } else {
+            return dir.child(subdirOrNull);
+        }
+    }
+
+    private Date downloadOnNodeWithFallbackToMaster(@Nonnull final URI uri,
+            @CheckForNull final Long timestampOfLocalContents, @CheckForNull final String usernameOrNull,
+            @CheckForNull final String passwordOrNull, @Nonnull final String nodeName, @Nonnull final FilePath dir,
+            @CheckForNull final TaskListener logOrNull) throws IOException, InterruptedException {
+        if (dir.isRemote()) {
+            /*
+             * if (log != null) {
+             * log.getLogger().println("Trying download from remote node " +
+             * nodeName); }
+             */
+            try {
+                final Date timestampOfRemoteResource = downloadOnRemoteNode(uri, timestampOfLocalContents,
+                        usernameOrNull, passwordOrNull, dir, logOrNull, nodeName);
+                /*
+                 * if (log != null) { if (timestampOfRemoteResource != null) {
+                 * log.getLogger().println("Download from remote node " +
+                 * nodeName + " successful, timestamp of resource is now " +
+                 * timestampOfRemoteResource.getTime() + " (aka " +
+                 * timestampOfRemoteResource + ")"); } else {
+                 * log.getLogger().println("Download from remote node " +
+                 * nodeName + " skipped"); } }
+                 */
+                return timestampOfRemoteResource;
+            } catch (AuthenticatedDownloadCallable.HttpGetException | InterruptedException ex) {
+                // No point retrying from master. The failure was not caused by
+                // our inability to talk to URI.
+                throw ex;
+            } catch (IOException ex) {
+                if (logOrNull != null) {
+                    Functions.printStackTrace(ex,
+                            logOrNull.error("Failed to download " + uri + " from agent; will try from master instead"));
+                }
+            }
+        }
+        /*
+         * if (log != null) { log.getLogger().println(
+         * "Trying download from master, piping data to node " + nodeName); }
+         */
+        final Date timestampOfRemoteResource = downloadOnFromMaster(uri, timestampOfLocalContents, usernameOrNull,
+                passwordOrNull, dir, logOrNull, nodeName);
+        /*
+         * if (log != null) { if (timestampOfRemoteResource != null) {
+         * log.getLogger() .println("Download from master to node " + nodeName +
+         * " successful, timestamp of resource is now " +
+         * timestampOfRemoteResource.getTime() + " (aka " +
+         * timestampOfRemoteResource + ")"); } else {
+         * log.getLogger().println("Download from master to node " + nodeName +
+         * " skipped"); } }
+         */
+        return timestampOfRemoteResource;
+    }
+
+    protected StandardCredentials lookupConfiguredCredentials(@CheckForNull final String urlHostOrNullOrEmpty)
+            throws ExtraToolInstallersException {
+        final String credentialsIdOrNull = getCredentialsId();
+        if (credentialsIdOrNull == null) {
+            return null;
+        }
+        final StandardCredentials credentialsOrNull = getCredentialsOrNull(credentialsIdOrNull, urlHostOrNullOrEmpty);
+        if (credentialsOrNull == null) {
+            throw new ExtraToolInstallersException(this,
+                    Messages.AuthenticatedZipExtractionInstaller_invalid_credentials(credentialsIdOrNull));
+        }
+        return credentialsOrNull;
+    }
+
+    protected Date downloadOnFromMaster(@Nonnull final URI uri, @CheckForNull final Long timestampOfLocalContents,
+            @CheckForNull final String usernameOrNull, @CheckForNull final String passwordOrNull,
+            @Nonnull final FilePath dir, @CheckForNull final TaskListener logOrNull, @Nonnull final String nodeName)
+            throws IOException, InterruptedException {
+        final Date timestampOfRemoteResource = AuthenticatedDownloadCallable.downloadAndUnpack(uri, usernameOrNull,
+                passwordOrNull, timestampOfLocalContents, nodeName, dir, logOrNull);
+        return timestampOfRemoteResource;
+    }
+
+    protected Date downloadOnRemoteNode(@Nonnull final URI uri, @CheckForNull final Long timestampOfLocalContents,
+            @CheckForNull final String usernameOrNull, @CheckForNull final String passwordOrNull,
+            @Nonnull final FilePath dir, @CheckForNull final TaskListener logOrNull, @Nonnull final String nodeName)
+            throws IOException, InterruptedException {
+        final AuthenticatedDownloadCallable nodeOperation = new AuthenticatedDownloadCallable(uri, usernameOrNull,
+                passwordOrNull, timestampOfLocalContents, nodeName, logOrNull);
+        final Date timestampOfRemoteResource = dir.act(nodeOperation);
+        return timestampOfRemoteResource;
+    }
+
+    /**
+     * Looks up credentials by ID, ensuring they're valid for the specified host
+     */
+    private static @CheckForNull StandardCredentials getCredentialsOrNull(@Nonnull final String credentialsId,
+            @CheckForNull final String urlHostOrNullOrEmpty) {
+        final List<DomainRequirement> forOurUrl = getDomainRequirements(urlHostOrNullOrEmpty);
+        final ItemGroup<?> allOfJenkins = Jenkins.getInstance();
+        final CredentialsMatcher onlyOurCredentials = CredentialsMatchers.allOf(CREDENTIAL_TYPES_WE_CAN_HANDLE,
+                CredentialsMatchers.withId(credentialsId));
+        final List<StandardCredentials> allJenkinsCredentialsForOurUrl = CredentialsProvider
+                .lookupCredentials(StandardCredentials.class, allOfJenkins, ACL.SYSTEM, forOurUrl);
+        final StandardCredentials ourCredentialsOrNull = CredentialsMatchers.firstOrNull(allJenkinsCredentialsForOurUrl,
+                onlyOurCredentials);
+        return ourCredentialsOrNull;
+    }
+
+    /** Extracts the username from any credential type we support. */
+    private static @CheckForNull String getUsernameFromCredentials(@Nonnull StandardCredentials credentials) {
+        if (credentials instanceof UsernameCredentials) {
+            final UsernameCredentials userCreds = (UsernameCredentials) credentials;
+            return userCreds.getUsername();
+        } else {
+            return null;
+        }
+    }
+
+    /** Extracts the password from any credential type we support. */
+    private static @CheckForNull String getPasswordFromCredentials(@Nonnull StandardCredentials credentials) {
+        if (credentials instanceof PasswordCredentials) {
+            final PasswordCredentials pwdCreds = (PasswordCredentials) credentials;
+            return Secret.toString(pwdCreds.getPassword());
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Defines what credential types are supported by
+     * {@link #getUsernameFromCredentials(StandardCredentials)} and
+     * {@link #getPasswordFromCredentials(StandardCredentials)}
+     */
+    private static final CredentialsMatcher CREDENTIAL_TYPES_WE_CAN_HANDLE = CredentialsMatchers.anyOf(
+            CredentialsMatchers.instanceOf(PasswordCredentials.class),
+            CredentialsMatchers.instanceOf(UsernameCredentials.class));
+
+    /** Limits credentials to those available to our URL's server. */
+    private static @Nonnull List<DomainRequirement> getDomainRequirements(
+            @CheckForNull final String urlHostOrNullOrEmpty) {
+        if (Util.fixEmpty(urlHostOrNullOrEmpty) != null) {
+            return Collections.<DomainRequirement>singletonList(new HostnameRequirement(urlHostOrNullOrEmpty));
+        } else {
+            return Collections.<DomainRequirement>emptyList();
+        }
+    }
+
+    /** Copy of hudson.tools.ZipExtractionInstaller.ChmodRecAPlusX */
+    static class ChmodRecAPlusX extends MasterToSlaveFileCallable<Void> {
+        private static final long serialVersionUID = 1L;
+
+        public Void invoke(File d, VirtualChannel channel) throws IOException {
+            if (!Functions.isWindows())
+                process(d);
+            return null;
+        }
+
+        private void process(File f) {
+            if (f.isFile()) {
+                f.setExecutable(true, false);
+            } else {
+                File[] kids = f.listFiles();
+                if (kids != null) {
+                    for (File kid : kids) {
+                        process(kid);
+                    }
+                }
+            }
+        }
+    }
+
+    @Extension @Symbol("authenticatedzip")
+    public static class DescriptorImpl extends ToolInstallerDescriptor<AuthenticatedZipExtractionInstaller> {
+        public String getDisplayName() {
+            return Messages.AuthenticatedZipExtractionInstaller_DescriptorImpl_displayName();
+        }
+
+        /* List credentials that can be used on the specified URL */
+        public ListBoxModel doFillCredentialsIdItems(@QueryParameter String credentialsId, @QueryParameter String url) {
+            /*
+             * System.out.println("doFillCredentialsIdItems(" + item + "," +
+             * credentialsId + "," + url + ")");
+             */
+            final StandardListBoxModel result = new StandardListBoxModel();
+            if (hasPermissionToConfigure()) {
+                result.includeEmptyValue();
+                String urlHostOrNullOrEmpty = null;
+                try {
+                    final String urlString = Util.fixEmpty(url);
+                    if (urlString != null) {
+                        final URI uri = new URI(urlString, false);
+                        urlHostOrNullOrEmpty = uri.getHost();
+                    }
+                } catch (URIException ex) {
+                    /*
+                     * System.out.println("  url = invalid, ex=" +
+                     * ex.toString());
+                     */
+                    // suppress exception as url is validated elsewhere
+                }
+                /* System.out.println("  urlHost = " + urlHost); */
+                final ItemGroup<?> allOfJenkins = Jenkins.getInstance();
+                final List<DomainRequirement> domainRequirements = getDomainRequirements(urlHostOrNullOrEmpty);
+                result.includeMatchingAs(ACL.SYSTEM, allOfJenkins, StandardCredentials.class, domainRequirements,
+                        CREDENTIAL_TYPES_WE_CAN_HANDLE);
+            }
+            result.includeCurrentValue(credentialsId);
+            /* System.out.println("  result = " + result); */
+            return result;
+        }
+
+        /*
+         * Validates our URL+Credentials, but only returns an error if there's a
+         * problem with the Credentials.
+         */
+        @RequirePOST // validation will expose credentials to the url
+        public FormValidation doCheckCredentialsId(@QueryParameter String value, @QueryParameter String url) {
+            /*
+             * System.out.println("doCheckCredentialsId(" + item + "," + value +
+             * "," + url + ")");
+             */
+            final String urlOrNull = Util.fixEmpty(url);
+            final String credentialsIdOrNull = Util.fixEmpty(value);
+            return checkUrlAndCredentialsId(false, credentialsIdOrNull, urlOrNull);
+        }
+
+        /*
+         * Validates our URL+Credentials, but only returns an error if there's a
+         * problem with the URL.
+         */
+        @RequirePOST // validation will expose credentials to the url
+        public FormValidation doCheckUrl(@QueryParameter String credentialsId, @QueryParameter String value) {
+            /*
+             * System.out.println("doCheckUrl(" + item + "," + credentialsId +
+             * "," + value + ")");
+             */
+            final String urlOrNull = Util.fixEmpty(value);
+            final String credentialsIdOrNull = Util.fixEmpty(credentialsId);
+            return checkUrlAndCredentialsId(true, credentialsIdOrNull, urlOrNull);
+        }
+
+        /**
+         * Validates the URL + Credentials as a pair.
+         * 
+         * @param checkUrl
+         *            If true then we should only return URL problems and just
+         *            return {@link FormValidation#ok()} if there's a credential
+         *            problem. If false then we should only return credential
+         *            problems and just return {@link FormValidation#ok()} if
+         *            there's a URL problem.
+         * @param item
+         *            Context for overall configuration permission check.
+         * @param credentialsIdOrNull
+         *            The credentials to check.
+         * @param urlOrNull
+         *            The URL to check. If we have non-null credentials then
+         *            we'll verify the URL is reachable with those credentials;
+         *            if we have null credentials then we'll verify that the URL
+         *            is reachable via anonymous download.
+         * @return If <code>checkUrl</code> is true then we return what's wrong
+         *         (if anything) with the URL. If <code>checkUrl</code> is false
+         *         then we return what's wrong (if anything) with the
+         *         credentials.
+         */
+        private static @Nonnull FormValidation checkUrlAndCredentialsId(final boolean checkUrl,
+                @CheckForNull final String credentialsIdOrNull, @CheckForNull final String urlOrNull) {
+            if (!(hasPermissionToConfigure())) {
+                /*
+                 * System.out.println(
+                 * "checkUrlAndCredentialsId:  NOT hasPermissionToConfigure");
+                 */
+                return FormValidation.ok();
+            }
+            if (urlOrNull == null) {
+                /*
+                 * System.out.println("checkUrlAndCredentialsId:  url = null");
+                 */
+                return urlProblem(checkUrl, FormValidation.validateRequired(""));
+            }
+            final URI uri;
+            final String urlHostOrNullOrEmpty;
+            try {
+                uri = new URI(urlOrNull, false);
+                urlHostOrNullOrEmpty = uri.getHost();
+            } catch (URIException ex) {
+                /*
+                 * System.out.println(
+                 * "checkUrlAndCredentialsId:  url = invalid, ex=" +
+                 * ex.toString());
+                 */
+                return urlProblem(checkUrl,
+                        FormValidation.error(ex, Messages.AuthenticatedZipExtractionInstaller_malformed_url()));
+            }
+            final String usernameOrNull;
+            final String passwordOrNull;
+            /*
+             * System.out.println(
+             * "checkUrlAndCredentialsId:  credentialsIdOrNull = " +
+             * credentialsIdOrNull);
+             */
+            if (credentialsIdOrNull == null) {
+                usernameOrNull = null;
+                passwordOrNull = null;
+            } else {
+                final StandardCredentials credentialsOrNull = getCredentialsOrNull(credentialsIdOrNull,
+                        urlHostOrNullOrEmpty);
+                /*
+                 * System.out.println(
+                 * "checkUrlAndCredentialsId:  credentialsOrNull = " +
+                 * credentialsOrNull);
+                 */
+                if (credentialsOrNull == null) {
+                    return credentialProblem(checkUrl, FormValidation.error(
+                            Messages.AuthenticatedZipExtractionInstaller_invalid_credentials(credentialsIdOrNull)));
+                }
+                usernameOrNull = getUsernameFromCredentials(credentialsOrNull);
+                passwordOrNull = getPasswordFromCredentials(credentialsOrNull);
+            }
+            final Long timestampOfLocalContents = null;
+            final String nodeName = "";
+            final FilePath whereToDownloadToOrNull = null;
+            final TaskListener log = null;
+            try {
+                /*
+                 * System.out.println(
+                 * "checkUrlAndCredentialsId:  DownloadIfNecessary.payload(" +
+                 * uri + "," + usernameOrNull + "," + passwordOrNull + "," +
+                 * timestampOfLocalContents + "," + nodeName + "," +
+                 * whereToDownloadToOrNull + "," + log + ")");
+                 */
+                AuthenticatedDownloadCallable.downloadAndUnpack(uri, usernameOrNull, passwordOrNull,
+                        timestampOfLocalContents, nodeName, whereToDownloadToOrNull, log);
+            } catch (AuthenticatedDownloadCallable.HttpGetException ex) {
+                if (ex.getHttpStatusCode() != null) {
+                    final int httpStatusCode = ex.getHttpStatusCode().intValue();
+                    if (httpStatusCode == HttpStatus.SC_UNAUTHORIZED) {
+                        if (usernameOrNull == null) {
+                            return credentialProblem(checkUrl, FormValidation.error(ex,
+                                    Messages.AuthenticatedZipExtractionInstaller_credentials_required()));
+                        } else {
+                            return credentialProblem(checkUrl, FormValidation.error(ex,
+                                    Messages.AuthenticatedZipExtractionInstaller_credentials_rejected(usernameOrNull)));
+                        }
+                    }
+                    if (httpStatusCode == HttpStatus.SC_NOT_FOUND) {
+                        return credentialProblem(checkUrl, FormValidation.error(ex,
+                                Messages.AuthenticatedZipExtractionInstaller_404_http_response_from_server()));
+                    }
+                }
+                return urlProblem(checkUrl, FormValidation.error(ex,
+                        Messages.AuthenticatedZipExtractionInstaller_bad_http_response_from_server(ex.getMessage())));
+            } catch (IOException | InterruptedException ex) {
+                return urlProblem(checkUrl,
+                        FormValidation.error(ex, Messages.AuthenticatedZipExtractionInstaller_could_not_connect()));
+            }
+            return FormValidation.ok();
+        }
+
+        private static @Nonnull FormValidation urlProblem(final boolean checkUrlNotCredentials,
+                @Nonnull final FormValidation problemWithUrl) {
+            return checkUrlNotCredentials ? problemWithUrl : FormValidation.ok();
+        }
+
+        private static @Nonnull FormValidation credentialProblem(final boolean checkUrlNotCredentials,
+                @Nonnull final FormValidation problemWithCredentials) {
+            return checkUrlNotCredentials ? FormValidation.ok() : problemWithCredentials;
+        }
+
+        private static boolean hasPermissionToConfigure() {
+            return Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER);
+        }
+    }
+}

--- a/src/main/resources/io/jenkins/plugins/extratoolinstallers/installers/AuthenticatedZipExtractionInstaller/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/extratoolinstallers/installers/AuthenticatedZipExtractionInstaller/config.jelly
@@ -1,0 +1,13 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:c="lib/credentials" xmlns:t="/hudson/tools">
+    <t:label />
+    <f:entry title="${%Download URL for binary archive}" field="url">
+        <f:textbox checkMethod="post"/>
+    </f:entry>
+    <f:entry title="${%Credentials}" field="credentialsId">
+        <c:select checkMethod="post"/>
+    </f:entry>
+    <f:entry title="${%Subdirectory of extracted archive}" field="subdir">
+        <f:textbox/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/extratoolinstallers/installers/AuthenticatedZipExtractionInstaller/help-credentialsId.html
+++ b/src/main/resources/io/jenkins/plugins/extratoolinstallers/installers/AuthenticatedZipExtractionInstaller/help-credentialsId.html
@@ -1,0 +1,6 @@
+<p>
+A username and password to use for authentication when downloading from the specified URL.
+</p>
+<p>
+This can be set to "none" to use unauthenticated downloads, but if you don't need authentication then you could use the core functionality instead.
+</p>

--- a/src/main/resources/io/jenkins/plugins/extratoolinstallers/installers/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/extratoolinstallers/installers/Messages.properties
@@ -1,0 +1,14 @@
+AuthenticatedZipExtractionInstaller.DescriptorImpl.displayName=Download (with basic authentication) and extract *.zip/*.tar.gz 
+AuthenticatedZipExtractionInstaller.invalid_credentials=Currently selected credentials (ID {0}) are not valid.
+AuthenticatedZipExtractionInstaller.credentials_required=Credentials are required.
+AuthenticatedZipExtractionInstaller.credentials_rejected=Credentials for user "{0}" were rejected.
+AuthenticatedZipExtractionInstaller.download_skipped=Skipping download of {0} as {1} is up to date on {2}.
+AuthenticatedZipExtractionInstaller.anonymous_download_newer=Anonymously downloading {0} into {1} on {2} because existing contents is out of date.
+AuthenticatedZipExtractionInstaller.authenticated_download_newer=Downloading {0} as {1} into {2} on {3} because existing contents is out of date.
+AuthenticatedZipExtractionInstaller.anonymous_download_new=Anonymously downloading {0} into {1} on {2}.
+AuthenticatedZipExtractionInstaller.authenticated_download_new=Downloading {0} as {1} into {2} on {3}.
+AuthenticatedZipExtractionInstaller.404_http_response_from_server=Resource not found.
+AuthenticatedZipExtractionInstaller.bad_http_response_from_server=Could not download from server: {0}
+AuthenticatedZipExtractionInstaller.malformed_url=Malformed URL.
+AuthenticatedZipExtractionInstaller.could_not_connect=Could not connect to URL.
+AuthenticatedZipExtractionInstaller.unpack_failed=Failed to unpack {0} ({1} bytes read of total {2})


### PR DESCRIPTION
Much as the core download-and-unpack method, but this supports basic authentication on the download.
With increasing focus on security, HTTP is giving way to HTTPS and anonymous is giving way to authenticated access.  This allows custom tools etc to be downloaded from servers that do not permit anonymous downloads.