### PR TITLE
Undeprecate BatchCommandInstaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ You can find more info on the [plugin's page](https://plugins.jenkins.io/extra-t
 Features
 --------
 
-* Batch command installer for tool installations on Windows. 
-  * `@Deprecated`. Jenkins Core supports such installer since 1.549 (see [JENKINS-21202](https://issues.jenkins-ci.org/browse/JENKINS-21202))
+* Batch command installer for Windows that supports Jenkins variable substitution.
 * "Install from specified folder" - setup without any actions (ex, "installation" from a shared directory)
 * "Skip or fail installation" - prints warnings during the installation and/or fails the installation
 * "Authenticated download and unpack of a zip/tar.gz.

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/extratoolinstallers/installers/BatchCommandInstaller.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/extratoolinstallers/installers/BatchCommandInstaller.java
@@ -40,9 +40,7 @@ import org.kohsuke.stapler.QueryParameter;
  * Installs tool via script execution of Batch script.
  * Inspired by the {@link hudson.tools.CommandInstaller} from the Jenkins core.
  * @since 0.1
- * @deprecated {@link hudson.tools.BatchCommandInstaller} is now available in the core.
  */
-@Deprecated
 public class BatchCommandInstaller extends AbstractExtraToolInstaller {
 
     /**

--- a/src/main/resources/com/synopsys/arc/jenkinsci/plugins/extratoolinstallers/installers/Messages.properties
+++ b/src/main/resources/com/synopsys/arc/jenkinsci/plugins/extratoolinstallers/installers/Messages.properties
@@ -1,4 +1,4 @@
-BatchCommandInstaller.DescriptorImpl.displayName=Run Batch Command (extra-tool-installers)
+BatchCommandInstaller.DescriptorImpl.displayName=Run Batch Command (with variable substitution)
 BatchCommandInstaller.no_command=Must provide a command to run.
 BatchCommandInstaller.no_toolHome=Must provide a tool home directory.
 SharedDirectoryInstaller.DescriptorImpl.displayName=Use tool from the specified directory


### PR DESCRIPTION
The core implementation isn't equivalent, so this remains valid.
