### PR TITLE
Fix compilation with Java 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,2 @@
 // Build the plugin using https://github.com/jenkins-infra/pipeline-library
-buildPlugin()
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())


### PR DESCRIPTION
Without this change `mvn compile` fails with the following error message:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project extra-tool-installers: Compilation failure
[ERROR] java.nio.file.NoSuchFileException: .../extra-tool-installers-plugin/target/classes/META-INF/annotations/hudson.Extension
```

See [JENKINS-52024](https://issues.jenkins-ci.org/browse/JENKINS-52024) why the minimum Jenkins version had to be raised.
