### PR TITLE
Legal stuff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# General
+
+- Please do not use the issue tracker to ask questions, join jenkins-users mailing list.
+This facility is for reporting (and fixing) bugs in the code.
+If you're not 100% sure it's a bug in the code then please seek help elsewhere.
+- [RTFM](https://en.wikipedia.org/wiki/RTFM). The Jenkins UI pages include help that should explain things. The [the plugin's wiki page](https://wiki.jenkins.io/display/JENKINS/Extra+Tool+Installers+Plugin) gives additional information.
+- Be helpful and make no demands.
+  * This code is Free Open-Source Software - nobody is obliged to make things work for you *but* you have legal permission to fix things yourself.
+  * If you're reporting and fixing an issue yourself then you only need to explain what problem you're fixing in enough detail that the maintainer(s) can understand why your changes are in the public interest.
+  * If you're relying on someone else to fix a problem then you should to make it as easy as possible for others to fix it for you, and you should test any fixes provided.
+
+# Creating new issue
+
+- Provide a full description of the issue you are facing.
+  * What are you trying to do?
+  * How is this failing?
+  * What should happen instead?
+- Provide step-by-step instructions for how to reproduce the issue.
+- Specify the Jenkins core & plugin version you're seeing the issue with.
+- Check and provide errors from the build log and any errors from `Manage Jenkins` -> `System Log`.
+  * Exceptions and stacktraces are *especially* useful, so don't omit those...
+  * Note that sensitive information may be visible in logs, so take care to redact logs where necessary.
+- Ensure that any code or log example surround with [the right markdown](https://help.github.com/articles/github-flavored-markdown/) otherwise it'll be unreadable.
+
+# For pull requests
+
+- Legal notice:
+  * Any code submitted will be subject to the same license as the rest of the code. No new restrictions/conditions are permitted.
+  * As a contributor, you MUST have the legal right to grant permission for the contribution to be used under these conditions.
+- A PR's description must EITHER refer to an existing issue (either in github or on Jenkins JIRA) OR include a full description as for "Creating new issue".
+- A single PR should EITHER be making functional changes OR making (non-functional) cosmetic/refactoring changes to the code.
+Please do not do both in the same PR or it makes life difficult for anyone else merging your changes.
+- For functional-change PRs, keep changes to a minimum (to make merges easier).
+- Clean build & test:
+  * Any submitted PRs should automatically get built and tested; PRs will not be considered for merger until they are showing a clean build.
+  If you believe that the build failed for reasons unconnected to your changes, close your PR, wait 10 minutes, then re-open it (just re-open the same PR; don't create a new one) to trigger a rebuild.
+  Repeat until it builds clean, changing your code if necessary.
+  * Please provide unit-tests for your contribution.
+  * Don't give findbugs, the compiler or any IDEs anything new to complain about.
+
+# Links
+
+- https://wiki.jenkins.io/display/JENKINS/Extra+Tool+Installers+Plugin
+- https://wiki.jenkins.io/display/JENKINS/Beginners+Guide+to+Contributing
+- https://wiki.jenkins.io/display/JENKINS/Extend+Jenkins

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,12 @@ If you're not 100% sure it's a bug in the code then please seek help elsewhere.
   * If you're reporting and fixing an issue yourself then you only need to explain what problem you're fixing in enough detail that the maintainer(s) can understand why your changes are in the public interest.
   * If you're relying on someone else to fix a problem then you should to make it as easy as possible for others to fix it for you, and you should test any fixes provided.
 
-# Creating new issue
+# Legal conditions
+
+- Any contributions (code, information etc) submitted will be subject to the same license as the rest of the code. No new restrictions/conditions are permitted.
+- As a contributor, you MUST have the legal right to grant permission for the contribution to be used under these conditions.
+
+# Reporting a new issue
 
 - Provide a full description of the issue you are facing.
   * What are you trying to do?
@@ -22,14 +27,11 @@ If you're not 100% sure it's a bug in the code then please seek help elsewhere.
   * Note that sensitive information may be visible in logs, so take care to redact logs where necessary.
 - Ensure that any code or log example surround with [the right markdown](https://help.github.com/articles/github-flavored-markdown/) otherwise it'll be unreadable.
 
-# For pull requests
+# Submitting pull requests
 
-- Legal notice:
-  * Any code submitted will be subject to the same license as the rest of the code. No new restrictions/conditions are permitted.
-  * As a contributor, you MUST have the legal right to grant permission for the contribution to be used under these conditions.
 - A PR's description must EITHER refer to an existing issue (either in github or on Jenkins JIRA) OR include a full description as for "Creating new issue".
 - A single PR should EITHER be making functional changes OR making (non-functional) cosmetic/refactoring changes to the code.
-Please do not do both in the same PR or it makes life difficult for anyone else merging your changes.
+Please do not do both in the same PR as this makes life difficult for anyone else merging your changes.
 - For functional-change PRs, keep changes to a minimum (to make merges easier).
 - Clean build & test:
   * Any submitted PRs should automatically get built and tested; PRs will not be considered for merger until they are showing a clean build.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,9 @@ The [plugin's wiki page](https://wiki.jenkins.io/display/JENKINS/Extra+Tool+Inst
 
 # Legal conditions
 
-- Any contributions (code, information etc) submitted will be subject to the same license as the rest of the code. No new restrictions/conditions are permitted.
-- As a contributor, you MUST have the legal right to grant permission for the contribution to be used under these conditions.
+- Any contributions (code, information etc) submitted will be subject to the same [license](LICENSE) as the rest of the code.
+No new restrictions/conditions are permitted.
+- As a contributor, you MUST have the legal right to grant permission for your contribution to be used under these conditions.
 
 # Reporting a new issue
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,12 @@
 # General
 
-- Please do not use the issue tracker to ask questions, join jenkins-users mailing list.
+- Please do not use the issue tracker to ask questions.
 This facility is for reporting (and fixing) bugs in the code.
 If you're not 100% sure it's a bug in the code then please seek help elsewhere.
-- [RTFM](https://en.wikipedia.org/wiki/RTFM). The Jenkins UI pages include help that should explain things. The [the plugin's wiki page](https://wiki.jenkins.io/display/JENKINS/Extra+Tool+Installers+Plugin) gives additional information.
+e.g. the [jenkins-users google group](https://groups.google.com/forum/#!forum/jenkinsci-users).
+- [RTFM](https://en.wikipedia.org/wiki/RTFM).
+The Jenkins UI pages include help that should explain things.
+The [plugin's wiki page](https://wiki.jenkins.io/display/JENKINS/Extra+Tool+Installers+Plugin) gives additional information.
 - Be helpful and make no demands.
   * This code is Free Open-Source Software - nobody is obliged to make things work for you *but* you have legal permission to fix things yourself.
   * If you're reporting and fixing an issue yourself then you only need to explain what problem you're fixing in enough detail that the maintainer(s) can understand why your changes are in the public interest.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-# Extra Tool Installers Plugin for Jenkins
+# Extra Tool Installers plugin for Jenkins
 
 This plugin provides additional tool installers for Jenkins.
+
+[![Build Status](https://ci.jenkins.io/job/Plugins/job/extra-tool-installers-plugin/job/master/badge/icon)](https://ci.jenkins.io/job/Plugins/job/extra-tool-installers-plugin/job/master/)
+
 You can find more info on the [plugin's page](https://plugins.jenkins.io/extra-tool-installers).
 
 ## Features


### PR DESCRIPTION
We didn't have any contribution guidelines to mention the requirement that ALL contributions have to be released under the same license as the rest of the plugin (MIT in this case).
My friendly corporate lawyer suggested that it'd be a good idea to make this clear.

I've also added a ton of other "if you're writing a PR, please ensure..." stuff in the hope that folks might do that.

See also similar PRs, as any comments/changes there may be relevant here:
1. https://github.com/jenkinsci/docker-plugin/pull/749
1. https://github.com/jenkinsci/vsphere-cloud-plugin/pull/109
1. https://github.com/jenkinsci/wsclean-plugin/pull/8