### PR TITLE
Update dependencies and pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,21 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.47</version>
+        <version>4.0</version>
     </parent>
 
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>extra-tool-installers</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <name>Jenkins Extra Tool Installers Plugin</name>
-    <description>Provides additional tool installers</description>
+    <description>Provides additional tool installation methods.</description>
     <packaging>hpi</packaging>
     <url>https://github.com/jenkinsci/extra-tool-installers-plugin</url>
 
     <properties>
-        <jenkins.version>2.60.3</jenkins.version>
+        <revision>1.1</revision>
+        <changelist>-SNAPSHOT</changelist>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jenkins.version>2.289.1</jenkins.version>
         <java.level>8</java.level>
     </properties>
 
@@ -56,22 +60,32 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
             <!-- Earliest version that supports c:select checkMethod="post" is 2.1.15, dated Sep 6 2017. -->
-            <version>2.1.15</version>
         </dependency>
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
-            <version>1.3</version>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.289.x</artifactId>
+                <version>841.vd6e713d848ab</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <scm>
         <connection>scm:git:ssh://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>

--- a/src/test/java/io/jenkins/plugins/extratoolinstallers/installers/AnyOfInstallerTest.java
+++ b/src/test/java/io/jenkins/plugins/extratoolinstallers/installers/AnyOfInstallerTest.java
@@ -1,7 +1,8 @@
 package io.jenkins.plugins.extratoolinstallers.installers;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 import static com.google.common.collect.Lists.*;
 


### PR DESCRIPTION
Jenkins only supports versions back a certain amount before things like the plugin-updates facility stops working.
Jenkins version 2.60 fell off the edge of the support cliff a while ago, which meant that doing e.g. `mvn hpi:run` runs an out-of-support Jenkins where the plugin install/upgrade page doesn't work, which then makes testing difficult.

This PR updates the minimum version of Jenkins to a more recent version.
