### PR TITLE
Fix javadoc issues that caused release to fail.

### DIFF
--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/extratoolinstallers/installers/AbstractExtraToolInstaller.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/extratoolinstallers/installers/AbstractExtraToolInstaller.java
@@ -37,7 +37,14 @@ import hudson.tools.ToolInstaller;
 public abstract class AbstractExtraToolInstaller extends ToolInstaller {
     private boolean failOnSubstitution;
     private final String toolHome;
-    
+
+    /**
+     * Constructor that sets all fields.
+     * 
+     * @param label              The {@link ToolInstaller#getLabel()}.
+     * @param toolHome           Our {@link #getToolHome()}.
+     * @param failOnSubstitution Our {@link #isFailOnSubstitution()}.
+     */
     public AbstractExtraToolInstaller(String label, String toolHome, boolean failOnSubstitution) {
         super(label);
         this.failOnSubstitution = failOnSubstitution;
@@ -51,7 +58,7 @@ public abstract class AbstractExtraToolInstaller extends ToolInstaller {
     public final String getToolHome() {
         return toolHome;
     }
-    
+
     /**
      * Substitute variables and fail on errors.
      * @param stringName Name of the field

--- a/src/main/java/io/jenkins/plugins/extratoolinstallers/installers/AnyOfInstaller.java
+++ b/src/main/java/io/jenkins/plugins/extratoolinstallers/installers/AnyOfInstaller.java
@@ -36,7 +36,7 @@ import hudson.util.FormValidation;
  */
 public class AnyOfInstaller extends ToolInstaller {
     /**
-     * The list of installers we will attempt. Cannot be empty for this class to
+     * The list of installers we will attempt. Cannot be empty for this to
      * be valid.
      */
     @CheckForNull
@@ -54,6 +54,9 @@ public class AnyOfInstaller extends ToolInstaller {
      */
     private /* almost final */ int attemptsOfWholeList;
 
+    /**
+     * Default constructor.
+     */
     @DataBoundConstructor
     public AnyOfInstaller() {
         // we never have a label ourselves; we only ever have labels in our
@@ -61,11 +64,22 @@ public class AnyOfInstaller extends ToolInstaller {
         super(null);
     }
 
+    /**
+     * The list of installers we will attempt. Cannot be empty for this installer to be
+     * valid.
+     * 
+     * @return Our installers.
+     */
     @CheckForNull
     public InstallSourceProperty getInstallers() {
         return installers;
     }
 
+    /**
+     * Sets {@link #getInstallers()}.
+     * 
+     * @param installers The new value.
+     */
     @DataBoundSetter
     public void setInstallers(@Nullable final InstallSourceProperty installers) {
         this.installers = installers;
@@ -85,6 +99,11 @@ public class AnyOfInstaller extends ToolInstaller {
         return Math.max(1, attemptsPerInstaller);
     }
 
+    /**
+     * Sets {@link #getAttemptsPerInstaller()}.
+     * 
+     * @param attemptsPerInstaller The new value.
+     */
     @DataBoundSetter
     public void setAttemptsPerInstaller(final int attemptsPerInstaller) {
         this.attemptsPerInstaller = attemptsPerInstaller;
@@ -101,6 +120,11 @@ public class AnyOfInstaller extends ToolInstaller {
         return Math.max(1, attemptsOfWholeList);
     }
 
+    /**
+     * Sets {@link #getAttemptsOfWholeList()}.
+     * 
+     * @param attemptsOfWholeList The new value.
+     */
     @DataBoundSetter
     public void setAttemptsOfWholeList(final int attemptsOfWholeList) {
         this.attemptsOfWholeList = attemptsOfWholeList;

--- a/src/main/java/io/jenkins/plugins/extratoolinstallers/installers/AuthenticatedZipExtractionInstaller.java
+++ b/src/main/java/io/jenkins/plugins/extratoolinstallers/installers/AuthenticatedZipExtractionInstaller.java
@@ -64,6 +64,11 @@ public class AuthenticatedZipExtractionInstaller extends ToolInstaller {
     @CheckForNull
     private String subdir;
 
+    /**
+     * Constructor that sets mandatory fields.
+     * 
+     * @param label The {@link ToolInstaller#getLabel()}.
+     */
     @DataBoundConstructor
     public AuthenticatedZipExtractionInstaller(String label) {
         super(label);
@@ -353,6 +358,9 @@ public class AuthenticatedZipExtractionInstaller extends ToolInstaller {
         }
     }
 
+    /**
+     * Descriptor for the {@link AuthenticatedZipExtractionInstaller}.
+     */
     @Extension @Symbol("authenticatedzip")
     public static class DescriptorImpl extends ToolInstallerDescriptor<AuthenticatedZipExtractionInstaller> {
         public String getDisplayName() {

--- a/src/main/java/io/jenkins/plugins/extratoolinstallers/installers/IsAlreadyOnPath.java
+++ b/src/main/java/io/jenkins/plugins/extratoolinstallers/installers/IsAlreadyOnPath.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -60,6 +59,11 @@ public class IsAlreadyOnPath extends ToolInstaller {
     @CheckForNull
     private String versionMax;
 
+    /**
+     * Constructor that sets mandatory fields.
+     * 
+     * @param label The {@link ToolInstaller#getLabel()}.
+     */
     @DataBoundConstructor
     public IsAlreadyOnPath(String label) {
         super(label);
@@ -78,7 +82,7 @@ public class IsAlreadyOnPath extends ToolInstaller {
     /**
      * Sets {@link #getExecutableName()}.
      * 
-     * @param url New value.
+     * @param executable New value.
      */
     @DataBoundSetter
     public void setExecutableName(@Nullable String executable) {
@@ -99,7 +103,7 @@ public class IsAlreadyOnPath extends ToolInstaller {
     /**
      * Sets {@link #getRelativePath()}.
      * 
-     * @param subdir New value.
+     * @param relativePath New value.
      */
     @DataBoundSetter
     public void setRelativePath(@Nullable String relativePath) {
@@ -145,7 +149,7 @@ public class IsAlreadyOnPath extends ToolInstaller {
     }
 
     /**
-     * See {@link #setVersionCmd(List)}.
+     * See {@link #setVersionCmd(String[])}.
      * 
      * @param versionCmdString New value as multi-line string.
      */
@@ -201,14 +205,14 @@ public class IsAlreadyOnPath extends ToolInstaller {
      * @param versionPatternString New value.
      */
     @DataBoundSetter
-    public void setVersionPatternString(String versionPattern) {
-        if (Util.fixEmpty(versionPattern) != null) {
+    public void setVersionPatternString(String versionPatternString) {
+        if (Util.fixEmpty(versionPatternString) != null) {
             try {
-                this.versionPattern = Pattern.compile(versionPattern);
+                this.versionPattern = Pattern.compile(versionPatternString);
                 this.versionPatternString = null;
             } catch (PatternSyntaxException ex) {
                 this.versionPattern = null;
-                this.versionPatternString = versionPattern;
+                this.versionPatternString = versionPatternString;
             }
         } else {
             this.versionPattern = null;
@@ -327,6 +331,9 @@ public class IsAlreadyOnPath extends ToolInstaller {
         return new FindOnPathCallable(exeName, logOrNull);
     }
 
+    /**
+     * Descriptor for {@link IsAlreadyOnPath}.
+     */
     @Extension
     @Symbol("findonpath")
     public static class DescriptorImpl extends ToolInstallerDescriptor<IsAlreadyOnPath> {


### PR DESCRIPTION
When I tried to release 1.1, the release failed because of Javadoc errors.
(weirdly, ones that hadn't been flagged by the compile & test phase - it only showed up while trying to push the release to the update site)

This PR fixes those Javadoc errors, hopefully clearing the way for a release to work.
