### PR TITLE
Creating a fallback option for authenticated download

### DIFF
--- a/src/main/java/io/jenkins/plugins/extratoolinstallers/installers/AuthenticatedDownloadCallable.java
+++ b/src/main/java/io/jenkins/plugins/extratoolinstallers/installers/AuthenticatedDownloadCallable.java
@@ -54,45 +54,50 @@ class AuthenticatedDownloadCallable extends MasterToSlaveFileCallable<Date> {
     @CheckForNull
     private final TaskListener logOrNull;
 
+    private final boolean fallbackToExistingInstallation;
+
     /**
      * Passed to {@link FilePath#act(hudson.FilePath.FileCallable)} in order to
      * run
      * {@link #doDownload(HttpRequestBase, FilePath, TaskListener, URI, String, String)}
      * on a remote node.
-     * 
+     *
      * @param uri
      *            What to download.
      * @param usernameOrNull
      *            Username to authenticate as, or null for an anonymous
-     *            download.
+     *                                       download.
      * @param passwordOrNull
      *            Password for the username, or null for no password.
      * @param timestampOfLocalContents
      *            null for an unconditional download, else the timestamp of what
-     *            we have locally.
+     *                                       we have locally.
      * @param nodeName
      *            The name of the node we are downloading onto. Used for logging
-     *            purposes only.
+     *                                       purposes only.
      * @param logOrNull
      *            Where to log build progress. Can be null to suppress the
-     *            normal running commentary.
+     *                                       normal running commentary.
+     * @param fallbackToExistingInstallation
+     *          If set to true and an installation of the tool already exists the download won't fail.
      */
     AuthenticatedDownloadCallable(@NonNull URI uri, @CheckForNull String usernameOrNull,
-            @CheckForNull String passwordOrNull, @CheckForNull Long timestampOfLocalContents, @NonNull String nodeName,
-            @CheckForNull TaskListener logOrNull) {
+                                  @CheckForNull String passwordOrNull, @CheckForNull Long timestampOfLocalContents, @NonNull String nodeName,
+                                  @CheckForNull TaskListener logOrNull, boolean fallbackToExistingInstallation) {
         this.uri = uri;
         this.usernameOrNull = usernameOrNull;
         this.passwordOrNull = passwordOrNull;
         this.timestampOfLocalContents = timestampOfLocalContents;
         this.nodeName = nodeName;
         this.logOrNull = logOrNull;
+        this.fallbackToExistingInstallation = fallbackToExistingInstallation;
     }
 
     @Override
     public Date invoke(@NonNull File d, VirtualChannel channel) throws IOException, InterruptedException {
         final FilePath whereToDownloadTo = new FilePath(d);
         return downloadAndUnpack(uri, usernameOrNull, passwordOrNull, timestampOfLocalContents, nodeName,
-                whereToDownloadTo, logOrNull);
+                whereToDownloadTo, logOrNull, fallbackToExistingInstallation);
     }
 
     /**
@@ -133,7 +138,7 @@ class AuthenticatedDownloadCallable extends MasterToSlaveFileCallable<Date> {
     static Date downloadAndUnpack(@NonNull final URI uri, @CheckForNull final String usernameOrNull,
             @CheckForNull final String passwordOrNull, @CheckForNull final Long timestampOfLocalContents,
             @NonNull final String nodeName, @CheckForNull final FilePath whereToDownloadToOrNull,
-            @CheckForNull final TaskListener logOrNull) throws IOException, InterruptedException {
+            @CheckForNull final TaskListener logOrNull, final boolean fallbackToExistingInstallation) throws IOException, InterruptedException {
         final CloseableHttpClient httpClient = HttpClients.createDefault();
         final HttpClientContext httpClientContext = HttpClientContext.create();
         final HttpRequestBase httpRequest;
@@ -189,6 +194,15 @@ class AuthenticatedDownloadCallable extends MasterToSlaveFileCallable<Date> {
                     }
                     break;
                 default :
+                    if (fallbackToExistingInstallation & existingToolInstallationAvailable(whereToDownloadToOrNull)) {
+                        if (logOrNull != null) {
+                            String msg = Messages.AuthenticatedDownloadCallable_fallback_to_existing(status);
+                            logOrNull.getLogger().println(msg);
+                        }
+                        dateOfRemoteContents = null;
+                        break;
+                    }
+
                     throw new HttpGetException(uri.toString(), usernameOrNull, status);
             }
             if (whereToDownloadToOrNull != null) {
@@ -203,6 +217,10 @@ class AuthenticatedDownloadCallable extends MasterToSlaveFileCallable<Date> {
             }
             return dateOfRemoteContents;
         }
+    }
+
+    private static boolean existingToolInstallationAvailable(FilePath whereToDownloadToOrNull) throws IOException, InterruptedException {
+        return whereToDownloadToOrNull != null && whereToDownloadToOrNull.exists();
     }
 
     private static void setAuthentication(@CheckForNull final String usernameOrNull,

--- a/src/main/java/io/jenkins/plugins/extratoolinstallers/installers/AuthenticatedZipExtractionInstaller.java
+++ b/src/main/java/io/jenkins/plugins/extratoolinstallers/installers/AuthenticatedZipExtractionInstaller.java
@@ -65,6 +65,8 @@ public class AuthenticatedZipExtractionInstaller extends ToolInstaller {
     @CheckForNull
     private String subdir;
 
+    private boolean fallbackToExistingInstallation;
+
     /**
      * Constructor that sets mandatory fields.
      * 
@@ -139,6 +141,15 @@ public class AuthenticatedZipExtractionInstaller extends ToolInstaller {
     @DataBoundSetter
     public void setSubdir(@Nullable String subdir) {
         this.subdir = Util.fixEmpty(subdir);
+    }
+
+    public boolean isFallbackToExistingInstallation() {
+        return fallbackToExistingInstallation;
+    }
+
+    @DataBoundSetter
+    public void setFallbackToExistingInstallation(boolean fallbackToExistingInstallation) {
+        this.fallbackToExistingInstallation = fallbackToExistingInstallation;
     }
 
     @Override
@@ -266,7 +277,7 @@ public class AuthenticatedZipExtractionInstaller extends ToolInstaller {
             @NonNull final FilePath dir, @CheckForNull final TaskListener logOrNull, @NonNull final String nodeName)
             throws IOException, InterruptedException {
         final Date timestampOfRemoteResource = AuthenticatedDownloadCallable.downloadAndUnpack(uri, usernameOrNull,
-                passwordOrNull, timestampOfLocalContents, nodeName, dir, logOrNull);
+                passwordOrNull, timestampOfLocalContents, nodeName, dir, logOrNull, fallbackToExistingInstallation);
         return timestampOfRemoteResource;
     }
 
@@ -275,7 +286,7 @@ public class AuthenticatedZipExtractionInstaller extends ToolInstaller {
             @NonNull final FilePath dir, @CheckForNull final TaskListener logOrNull, @NonNull final String nodeName)
             throws IOException, InterruptedException {
         final AuthenticatedDownloadCallable nodeOperation = new AuthenticatedDownloadCallable(uri, usernameOrNull,
-                passwordOrNull, timestampOfLocalContents, nodeName, logOrNull);
+                passwordOrNull, timestampOfLocalContents, nodeName, logOrNull, fallbackToExistingInstallation);
         final Date timestampOfRemoteResource = dir.act(nodeOperation);
         return timestampOfRemoteResource;
     }
@@ -524,7 +535,7 @@ public class AuthenticatedZipExtractionInstaller extends ToolInstaller {
                  * whereToDownloadToOrNull + "," + log + ")");
                  */
                 AuthenticatedDownloadCallable.downloadAndUnpack(uri, usernameOrNull, passwordOrNull,
-                        timestampOfLocalContents, nodeName, whereToDownloadToOrNull, log);
+                        timestampOfLocalContents, nodeName, whereToDownloadToOrNull, log, false);
             } catch (AuthenticatedDownloadCallable.HttpGetException ex) {
                 final Integer httpStatusCodeOrNull = ex.getHttpStatusCode();
                 if (httpStatusCodeOrNull != null) {

--- a/src/main/resources/io/jenkins/plugins/extratoolinstallers/installers/AuthenticatedZipExtractionInstaller/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/extratoolinstallers/installers/AuthenticatedZipExtractionInstaller/config.jelly
@@ -10,4 +10,7 @@
     <f:entry title="${%Subdirectory of extracted archive}" field="subdir" help="/descriptor/hudson.tools.ZipExtractionInstaller/help/subdir">
         <f:textbox/>
     </f:entry>
+    <f:entry title="${%Fallback to existing installation}">
+        <f:checkbox field="fallbackToExistingInstallation" />
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/extratoolinstallers/installers/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/extratoolinstallers/installers/Messages.properties
@@ -24,6 +24,8 @@ AuthenticatedZipExtractionInstaller.malformed_url=Malformed URL.
 AuthenticatedZipExtractionInstaller.could_not_connect=Could not connect to URL: {0}
 AuthenticatedZipExtractionInstaller.unpack_failed=Failed to unpack {0} ({1} bytes read of total {2})
 
+AuthenticatedDownloadCallable.fallback_to_existing=Tool download returned status code {0}. Fallback to existing installation.
+
 IsAlreadyOnPath.DescriptorImpl.displayName=Check tool is already on PATH
 IsAlreadyOnPath.agentIsOffline=Agent is not online
 IsAlreadyOnPath.executableNameIsEmpty=Executable Name field is empty


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
When using the authenticated download and the download url is currently not reachable the plugin causes the job to fail. This can be anoying when you have jobs running for weeks (e.g. migration jobs) and then crash on the end. 

Therefore I've implemented a fallback option which checks if the desired tool is already installed on the node and if yes, skips the download instead of fail. 

### Testing done

* Tested via hpi:run 
* Tested via hpi:hpi installation on a Jenkins instance with multiple nodes.

Test procedure: 
* Create a tool with authenticated download
* Create a Job which uses this tool configuration on a single agent
* Change the tool configuration to an url producing a 404 or any other error code
* Run the job. -> Job fails
* Add the fallback flag in the tools configuration
* Re-run the job -> Job succeeds as the tool is already installed by the first run.


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [-] Link to relevant issues in GitHub or Jira
- [-] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
